### PR TITLE
Support broadcast across subnets

### DIFF
--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -151,7 +151,7 @@ class Device:
         self._dirty = []
 
     async def bind(self, key=None):
-        """ Run the binding procedure.
+        """Run the binding procedure.
 
         Binding is a finnicky procedure, and happens in 1 of 2 ways:
             1 - Without the key, binding must pass the device info structure immediately following

--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -110,6 +110,24 @@ class DeviceInfo:
     def __str__(self):
         return f"Device: {self.name} @ {self.ip}:{self.port} (mac: {self.mac})"
 
+    def __eq__(self, other):
+        """Check equality based on Device Info properties"""
+        if isinstance(other, DeviceInfo):
+            return (
+                self.ip == other.ip
+                and self.port == other.port
+                and self.mac == other.mac
+                and self.name == other.name
+                and self.brand == other.brand
+                and self.model == other.model
+                and self.version == other.version
+            )
+        return False
+
+    def __ne__(self, other):
+        """Check inequality based on Device Info properties"""
+        return not self.__eq__(other)
+
 
 class Device:
     """Class representing a physical device, it's state and properties.

--- a/greeclimate/discovery.py
+++ b/greeclimate/discovery.py
@@ -16,7 +16,7 @@ class Discovery:
 
     @staticmethod
     async def search_devices() -> List[DeviceInfo]:
-        """ Sends a discovery broadcast packet on each network interface to
+        """Sends a discovery broadcast packet on each network interface to
             locate Gree units on the network
 
         Returns:

--- a/greeclimate/discovery.py
+++ b/greeclimate/discovery.py
@@ -25,7 +25,7 @@ class Discovery:
         _LOGGER.info("Starting Gree device discovery process")
 
         results = await nethelper.search_devices()
-        devices = [DeviceInfo(*d) for d in results]
+        devices = [DeviceInfo(*d) for d in list(set(results))]
         for d in devices:
             _LOGGER.info("Found %s", str(d))
 

--- a/greeclimate/network.py
+++ b/greeclimate/network.py
@@ -198,11 +198,12 @@ async def search_on_interface(bcast_iface: IPInterface, timeout: int):
     excq = asyncio.Queue()
     drained = asyncio.Event()
 
-    bcast = (bcast_iface.bcast_address, 7000)
+    bcast = ("255.255.255.255", 7000)
     local_addr = (bcast_iface.ip_address, 0)
 
     transport, _ = await loop.create_datagram_endpoint(
-        lambda: BroadcastListenerProtocol(recvq, excq, drained), local_addr=local_addr,
+        lambda: BroadcastListenerProtocol(recvq, excq, drained),
+        local_addr=local_addr,
     )
     stream = DatagramStream(transport, recvq, excq, drained, timeout)
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/cmroche/greeclimate",
-    packages=setuptools.find_packages(exclude=['tests']),
+    packages=setuptools.find_packages(exclude=["tests"]),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from greeclimate.device import Device, Props
+from greeclimate.device import Device, DeviceInfo, Props
 from greeclimate.discovery import Discovery
 from greeclimate.exceptions import DeviceNotBoundError, DeviceTimeoutError
 
@@ -87,6 +87,30 @@ async def generate_device_mock_async():
     await d.bind(key="St8Vw1Yz4Bc7Ef0H")
     return d
 
+
+def test_device_info_equality():
+    """ The only way to get the key through binding is by scanning first
+    """
+
+    props = [
+        "1.1.1.0",
+        "7000",
+        "aabbcc001122",
+        "MockDevice1",
+        "MockBrand",
+        "MockModel",
+        "0.0.1-fake",
+    ]
+
+    # When all properties match the device info is the same
+    assert DeviceInfo(*props) == DeviceInfo(*props)
+
+    # When any property differs the device info is not the same
+    for i in range(props):
+        new_props = props.copy()
+        new_props[i] = "modified_prop"
+        assert DeviceInfo(*new_props) != DeviceInfo(*props)
+    
 
 @pytest.mark.asyncio
 @patch("greeclimate.network.search_devices")

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -89,8 +89,7 @@ async def generate_device_mock_async():
 
 
 def test_device_info_equality():
-    """ The only way to get the key through binding is by scanning first
-    """
+    """The only way to get the key through binding is by scanning first"""
 
     props = [
         "1.1.1.0",
@@ -106,11 +105,11 @@ def test_device_info_equality():
     assert DeviceInfo(*props) == DeviceInfo(*props)
 
     # When any property differs the device info is not the same
-    for i in range(props):
+    for i in range(len(props)):
         new_props = props.copy()
         new_props[i] = "modified_prop"
         assert DeviceInfo(*new_props) != DeviceInfo(*props)
-    
+
 
 @pytest.mark.asyncio
 @patch("greeclimate.network.search_devices")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -27,3 +27,18 @@ async def test_discover_no_devices(mock_search_devices):
 
     assert devices is not None
     assert len(devices) == 0
+
+
+@pytest.mark.asyncio
+@patch("greeclimate.network.search_devices")
+async def test_discover_deduplicate_multiple_discoveries(mock_search_devices):
+    mock_search_devices.return_value = [
+        ("1.1.1.1", "7000", "aabbcc001122", "MockDevice1"),
+        ("1.1.1.1", "7000", "aabbcc001122", "MockDevice1"),
+        ("1.1.1.2", "7000", "aabbcc001123", "MockDevice2"),
+    ]
+
+    devices = await Discovery.search_devices()
+
+    assert devices is not None
+    assert len(devices) == 2

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -147,7 +147,11 @@ async def test_broadcast_recv(addr, bcast, family):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "addr,bcast,family", [(("127.0.0.1", 7000), "127.255.255.255", socket.AF_INET)]
+    "addr,bcast,family",
+    [
+        (("127.0.0.1", 7000), "127.255.255.255", socket.AF_INET),
+        (("127.0.0.1", 7000), "255.255.255.255", socket.AF_INET),
+    ],
 )
 async def test_broadcast_timeout(addr, bcast, family):
     """Create an async broadcast listener, test discovery responses."""
@@ -162,7 +166,8 @@ async def test_broadcast_timeout(addr, bcast, family):
     local_addr = (addr[0], 0)
 
     transport, _ = await loop.create_datagram_endpoint(
-        lambda: BroadcastListenerProtocol(recvq, excq, drained), local_addr=local_addr,
+        lambda: BroadcastListenerProtocol(recvq, excq, drained),
+        local_addr=local_addr,
     )
     stream = DatagramStream(transport, recvq, excq, drained, timeout=DEFAULT_TIMEOUT)
 


### PR DESCRIPTION
The goal is to support multiple subnets with a shared ethernet arp domain in device discovery by using 255.255.255.255 instead of 192.255.255.255 as the broadcast destination.

Actually this more closely resembles the network captures of the Gree+ app in general, and should be a bit more robust.

- [ ] Requires deduplication of device entries and 2 interfaces are on the same ether-arp domain