### PR TITLE
Bugfix for case where CID field is null

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "python.linting.enabled": true,
     "python.linting.lintOnSave": true,
     "python.linting.flake8Enabled": true,
-    "python.pythonPath": "venv/bin/python",
+    "python.pythonPath": "/usr/local/bin/python",
     "python.testing.unittestArgs": [
         "-v",
         "-s",

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Discover, connect and control Gree based mini-split systems.
 
 **greenclimat** is a ***fully async*** Python3 based package for controlling Gree based ACs and heat pumps. Gree is a common brand for mini-split systems and is licensed and resold under many product names. This module should work for any device that also works with the Gree+ app, but has been tested on
 
+- Proklima mini-splits units
 - Trane mini-split heat pump (4TXK38)
 
 _If you have tested and know of others systems that work, please fork and submit a PR with the make and model_

--- a/greeclimate/network.py
+++ b/greeclimate/network.py
@@ -221,7 +221,7 @@ async def search_on_interface(bcast_iface: IPInterface, timeout: int):
                 (
                     addr[0],
                     addr[1],
-                    pack["cid"],
+                    pack.get("mac") or pack.get("cid"),
                     pack.get("name"),
                     pack.get("brand"),
                     pack.get("model"),

--- a/network-log.txt
+++ b/network-log.txt
@@ -1,0 +1,109 @@
+2020-11-08 11:39:37 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 1, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "dev", "cid": "f4911e7aca59", "bc": "", "brand": "gree", "catalog": "gree", "mac": "f4911e7aca59", "mid": "10001", "model": "gree", "name": "1e7aca59", "series": "gree", "vender": "1", "ver": "V1.2.1", "lock": 0}}
+2020-11-08 11:39:37 DEBUG (MainThread) [greeclimate.network] Received response from device search
+{'t': 'dev', 'cid': 'f4911e7aca59', 'bc': '', 'brand': 'gree', 'catalog': 'gree', 'mac': 'f4911e7aca59', 'mid': '10001', 'model': 'gree', 'name': '1e7aca59', 'series': 'gree', 'vender': '1', 'ver': 'V1.2.1', 'lock': 0}
+
+2020-11-08 11:39:39 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 1, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "dev", "cid": "f4911e7aca59", "bc": "", "brand": "gree", "catalog": "gree", "mac": "f4911e7aca59", "mid": "10001", "model": "gree", "name": "1e7aca59", "series": "gree", "vender": "1", "ver": "V1.2.1", "lock": 0}}
+2020-11-08 11:39:39 DEBUG (MainThread) [greeclimate.network] Received response from device search
+{'t': 'dev', 'cid': 'f4911e7aca59', 'bc': '', 'brand': 'gree', 'catalog': 'gree', 'mac': 'f4911e7aca59', 'mid': '10001', 'model': 'gree', 'name': '1e7aca59', 'series': 'gree', 'vender': '1', 'ver': 'V1.2.1', 'lock': 0}
+
+2020-11-08 11:39:41 DEBUG (MainThread) [greeclimate.network] Sending packet:
+{"cid": "app", "i": "1", "t": "pack", "uid": 0, "tcid": "f4911e7aca59", "pack": {"mac": "f4911e7aca59", "t": "bind", "uid": 0}}
+2020-11-08 11:39:41 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 1, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "bindok", "mac": "f4911e7aca59", "key": "St8Vw1Yz4Bc7Ef0H", "r": 200}}
+2020-11-08 11:40:34 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 1, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "dev", "cid": "f4911e7aca59", "bc": "", "brand": "gree", "catalog": "gree", "mac": "f4911e7aca59", "mid": "10001", "model": "gree", "name": "1e7aca59", "series": "gree", "vender": "1", "ver": "V1.2.1", "lock": 0}}
+2020-11-08 11:40:34 DEBUG (MainThread) [greeclimate.network] Received response from device search
+{'t': 'dev', 'cid': 'f4911e7aca59', 'bc': '', 'brand': 'gree', 'catalog': 'gree', 'mac': 'f4911e7aca59', 'mid': '10001', 'model': 'gree', 'name': '1e7aca59', 'series': 'gree', 'vender': '1', 'ver': 'V1.2.1', 'lock': 0}
+2020-11-08 11:40:36 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 1, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "dev", "cid": "f4911e7aca59", "bc": "", "brand": "gree", "catalog": "gree", "mac": "f4911e7aca59", "mid": "10001", "model": "gree", "name": "1e7aca59", "series": "gree", "vender": "1", "ver": "V1.2.1", "lock": 0}}
+2020-11-08 11:40:36 DEBUG (MainThread) [greeclimate.network] Received response from device search
+{'t': 'dev', 'cid': 'f4911e7aca59', 'bc': '', 'brand': 'gree', 'catalog': 'gree', 'mac': 'f4911e7aca59', 'mid': '10001', 'model': 'gree', 'name': '1e7aca59', 'series': 'gree', 'vender': '1', 'ver': 'V1.2.1', 'lock': 0}
+
+2020-11-08 11:40:38 DEBUG (MainThread) [greeclimate.network] Sending packet:
+{"cid": "app", "i": "1", "t": "pack", "uid": 0, "tcid": "f4911e7aca59", "pack": {"mac": "f4911e7aca59", "t": "bind", "uid": 0}}
+2020-11-08 11:40:38 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 1, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "bindok", "mac": "f4911e7aca59", "key": "St8Vw1Yz4Bc7Ef0H", "r": 200}}
+2020-11-08 11:46:13 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 1, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "dev", "cid": "f4911e7aca59", "bc": "", "brand": "gree", "catalog": "gree", "mac": "f4911e7aca59", "mid": "10001", "model": "gree", "name": "1e7aca59", "series": "gree", "vender": "1", "ver": "V1.2.1", "lock": 0}}
+2020-11-08 11:46:13 DEBUG (MainThread) [greeclimate.network] Received response from device search
+{'t': 'dev', 'cid': 'f4911e7aca59', 'bc': '', 'brand': 'gree', 'catalog': 'gree', 'mac': 'f4911e7aca59', 'mid': '10001', 'model': 'gree', 'name': '1e7aca59', 'series': 'gree', 'vender': '1', 'ver': 'V1.2.1', 'lock': 0}
+2020-11-08 11:46:15 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 1, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "dev", "cid": "f4911e7aca59", "bc": "", "brand": "gree", "catalog": "gree", "mac": "f4911e7aca59", "mid": "10001", "model": "gree", "name": "1e7aca59", "series": "gree", "vender": "1", "ver": "V1.2.1", "lock": 0}}
+2020-11-08 11:46:15 DEBUG (MainThread) [greeclimate.network] Received response from device search
+{'t': 'dev', 'cid': 'f4911e7aca59', 'bc': '', 'brand': 'gree', 'catalog': 'gree', 'mac': 'f4911e7aca59', 'mid': '10001', 'model': 'gree', 'name': '1e7aca59', 'series': 'gree', 'vender': '1', 'ver': 'V1.2.1', 'lock': 0}
+2020-11-08 11:46:17 INFO (MainThread) [greeclimate.discovery] Found Device: 1e7aca59 @ 192.168.1.29:7000 (mac: f4911e7aca59)
+
+2020-11-08 11:46:17 INFO (MainThread) [greeclimate.device] Starting device binding to Device: 1e7aca59 @ 192.168.1.29:7000 (mac: f4911e7aca59)
+2020-11-08 11:46:17 DEBUG (MainThread) [greeclimate.network] Sending packet:
+{"cid": "app", "i": "1", "t": "pack", "uid": 0, "tcid": "f4911e7aca59", "pack": {"mac": "f4911e7aca59", "t": "bind", "uid": 0}}
+2020-11-08 11:46:17 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 1, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "bindok", "mac": "f4911e7aca59", "key": "St8Vw1Yz4Bc7Ef0H", "r": 200}}
+2020-11-08 11:50:22 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 1, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "dev", "cid": "f4911e7aca59", "bc": "", "brand": "gree", "catalog": "gree", "mac": "f4911e7aca59", "mid": "10001", "model": "gree", "name": "1e7aca59", "series": "gree", "vender": "1", "ver": "V1.2.1", "lock": 0}}
+2020-11-08 11:50:22 DEBUG (MainThread) [greeclimate.network] Received response from device search
+{'t': 'dev', 'cid': 'f4911e7aca59', 'bc': '', 'brand': 'gree', 'catalog': 'gree', 'mac': 'f4911e7aca59', 'mid': '10001', 'model': 'gree', 'name': '1e7aca59', 'series': 'gree', 'vender': '1', 'ver': 'V1.2.1', 'lock': 0}
+2020-11-08 11:50:24 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 1, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "dev", "cid": "f4911e7aca59", "bc": "", "brand": "gree", "catalog": "gree", "mac": "f4911e7aca59", "mid": "10001", "model": "gree", "name": "1e7aca59", "series": "gree", "vender": "1", "ver": "V1.2.1", "lock": 0}}
+2020-11-08 11:50:24 DEBUG (MainThread) [greeclimate.network] Received response from device search
+{'t': 'dev', 'cid': 'f4911e7aca59', 'bc': '', 'brand': 'gree', 'catalog': 'gree', 'mac': 'f4911e7aca59', 'mid': '10001', 'model': 'gree', 'name': '1e7aca59', 'series': 'gree', 'vender': '1', 'ver': 'V1.2.1', 'lock': 0}
+
+2020-11-08 11:50:26 DEBUG (MainThread) [greeclimate.network] Sending packet:
+{"cid": "app", "i": "1", "t": "pack", "uid": 0, "tcid": "f4911e7aca59", "pack": {"mac": "f4911e7aca59", "t": "bind", "uid": 0}}
+2020-11-08 11:50:26 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 1, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "bindok", "mac": "f4911e7aca59", "key": "St8Vw1Yz4Bc7Ef0H", "r": 200}}
+
+2020-11-08 11:50:26 DEBUG (MainThread) [greeclimate.network] Sending packet:
+{"cid": "app", "i": 0, "t": "pack", "uid": 0, "tcid": "f4911e7aca59", "pack": {"mac": "f4911e7aca59", "t": "status", "cols": ["Pow", "Mod", "SetTem", "TemUn", "TemRec", "WdSpd", "Air", "Blo", "Health", "SwhSlp", "Lig", "SwingLfRig", "SwUpDn", "Quiet", "Tur", "StHt", "SvSt", "HeatCoolType"]}}
+2020-11-08 11:50:26 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 0, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "dat", "mac": "f4911e7aca59", "r": 200, "cols": ["Pow", "Mod", "SetTem", "TemUn", "TemRec", "WdSpd", "Air", "Blo", "Health", "SwhSlp", "Lig", "SwingLfRig", "SwUpDn", "Quiet", "Tur", "StHt", "SvSt", "HeatCoolType"], "dat": [1, 4, 23, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0]}}
+
+2020-11-08 11:50:44 DEBUG (MainThread) [greeclimate.device] Pushing state updates to (Device: 1e7aca59 @ 192.168.1.29:7000 (mac: f4911e7aca59))
+2020-11-08 11:50:44 DEBUG (MainThread) [greeclimate.device] Sending remote state update Lig -> 0
+2020-11-08 11:50:44 DEBUG (MainThread) [greeclimate.network] Sending packet:
+{"cid": "app", "i": 0, "t": "pack", "uid": 0, "tcid": "f4911e7aca59", "pack": {"opt": ["Lig"], "p": [0], "t": "cmd"}}
+2020-11-08 11:50:44 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 0, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "res", "mac": "f4911e7aca59", "r": 200, "opt": ["Lig"], "p": [0], "val": [0]}}
+
+2020-11-08 11:51:25 DEBUG (MainThread) [greeclimate.device] Updating device properties for (Device: 1e7aca59 @ 192.168.1.29:7000 (mac: f4911e7aca59))
+2020-11-08 11:51:26 DEBUG (MainThread) [greeclimate.network] Sending packet:
+{"cid": "app", "i": 0, "t": "pack", "uid": 0, "tcid": "f4911e7aca59", "pack": {"mac": "f4911e7aca59", "t": "status", "cols": ["Pow", "Mod", "SetTem", "TemUn", "TemRec", "WdSpd", "Air", "Blo", "Health", "SwhSlp", "Lig", "SwingLfRig", "SwUpDn", "Quiet", "Tur", "StHt", "SvSt", "HeatCoolType"]}}
+2020-11-08 11:51:26 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 0, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "dat", "mac": "f4911e7aca59", "r": 200, "cols": ["Pow", "Mod", "SetTem", "TemUn", "TemRec", "WdSpd", "Air", "Blo", "Health", "SwhSlp", "Lig", "SwingLfRig", "SwUpDn", "Quiet", "Tur", "StHt", "SvSt", "HeatCoolType"], "dat": [1, 4, 23, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0]}}
+2020-11-08 11:51:26 DEBUG (MainThread) [homeassistant.components.gree.bridge] Finished fetching gree-1e7aca59 data in 0.019 seconds
+
+2020-11-08 11:52:26 DEBUG (MainThread) [greeclimate.device] Updating device properties for (Device: 1e7aca59 @ 192.168.1.29:7000 (mac: f4911e7aca59))
+2020-11-08 11:52:26 DEBUG (MainThread) [greeclimate.network] Sending packet:
+{"cid": "app", "i": 0, "t": "pack", "uid": 0, "tcid": "f4911e7aca59", "pack": {"mac": "f4911e7aca59", "t": "status", "cols": ["Pow", "Mod", "SetTem", "TemUn", "TemRec", "WdSpd", "Air", "Blo", "Health", "SwhSlp", "Lig", "SwingLfRig", "SwUpDn", "Quiet", "Tur", "StHt", "SvSt", "HeatCoolType"]}}
+2020-11-08 11:52:26 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 0, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "dat", "mac": "f4911e7aca59", "r": 200, "cols": ["Pow", "Mod", "SetTem", "TemUn", "TemRec", "WdSpd", "Air", "Blo", "Health", "SwhSlp", "Lig", "SwingLfRig", "SwUpDn", "Quiet", "Tur", "StHt", "SvSt", "HeatCoolType"], "dat": [1, 4, 23, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0]}}
+2020-11-08 11:52:26 DEBUG (MainThread) [homeassistant.components.gree.bridge] Finished fetching gree-1e7aca59 data in 0.030 seconds
+
+2020-11-08 11:52:45 DEBUG (MainThread) [greeclimate.device] Pushing state updates to (Device: 1e7aca59 @ 192.168.1.29:7000 (mac: f4911e7aca59))
+2020-11-08 11:52:45 DEBUG (MainThread) [greeclimate.device] Sending remote state update Lig -> 1
+2020-11-08 11:52:45 DEBUG (MainThread) [greeclimate.network] Sending packet:
+{"cid": "app", "i": 0, "t": "pack", "uid": 0, "tcid": "f4911e7aca59", "pack": {"opt": ["Lig"], "p": [1], "t": "cmd"}}
+2020-11-08 11:52:45 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 0, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "res", "mac": "f4911e7aca59", "r": 200, "opt": ["Lig"], "p": [1], "val": [1]}}
+
+2020-11-08 11:52:57 DEBUG (MainThread) [greeclimate.device] Pushing state updates to (Device: 1e7aca59 @ 192.168.1.29:7000 (mac: f4911e7aca59))
+2020-11-08 11:52:57 DEBUG (MainThread) [greeclimate.device] Sending remote state update WdSpd -> 5
+2020-11-08 11:52:57 DEBUG (MainThread) [greeclimate.network] Sending packet:
+{"cid": "app", "i": 0, "t": "pack", "uid": 0, "tcid": "f4911e7aca59", "pack": {"opt": ["WdSpd"], "p": [5], "t": "cmd"}}
+2020-11-08 11:52:57 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 0, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "res", "mac": "f4911e7aca59", "r": 200, "opt": ["WdSpd"], "p": [5], "val": [5]}}
+
+2020-11-08 11:53:01 DEBUG (MainThread) [greeclimate.device] Pushing state updates to (Device: 1e7aca59 @ 192.168.1.29:7000 (mac: f4911e7aca59))
+2020-11-08 11:53:01 DEBUG (MainThread) [greeclimate.device] Sending remote state update WdSpd -> 0
+2020-11-08 11:53:01 DEBUG (MainThread) [greeclimate.network] Sending packet:
+{"cid": "app", "i": 0, "t": "pack", "uid": 0, "tcid": "f4911e7aca59", "pack": {"opt": ["WdSpd"], "p": [0], "t": "cmd"}}
+2020-11-08 11:53:01 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 0, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "res", "mac": "f4911e7aca59", "r": 200, "opt": ["WdSpd"], "p": [0], "val": [0]}}
+
+2020-11-08 11:53:25 DEBUG (MainThread) [greeclimate.device] Updating device properties for (Device: 1e7aca59 @ 192.168.1.29:7000 (mac: f4911e7aca59))
+2020-11-08 11:53:26 DEBUG (MainThread) [greeclimate.network] Sending packet:
+{"cid": "app", "i": 0, "t": "pack", "uid": 0, "tcid": "f4911e7aca59", "pack": {"mac": "f4911e7aca59", "t": "status", "cols": ["Pow", "Mod", "SetTem", "TemUn", "TemRec", "WdSpd", "Air", "Blo", "Health", "SwhSlp", "Lig", "SwingLfRig", "SwUpDn", "Quiet", "Tur", "StHt", "SvSt", "HeatCoolType"]}}
+2020-11-08 11:53:26 DEBUG (MainThread) [greeclimate.network] Recived packet:
+{"t": "pack", "i": 0, "uid": 0, "cid": "f4911e7aca59", "tcid": "", "pack": {"t": "dat", "mac": "f4911e7aca59", "r": 200, "cols": ["Pow", "Mod", "SetTem", "TemUn", "TemRec", "WdSpd", "Air", "Blo", "Health", "SwhSlp", "Lig", "SwingLfRig", "SwUpDn", "Quiet", "Tur", "StHt", "SvSt", "HeatCoolType"], "dat": [1, 4, 23, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0]}}
+2020-11-08 11:53:26 DEBUG (MainThread) [homeassistant.components.gree.bridge] Finished fetching gree-1e7aca59 data in 0.023 seconds

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -43,6 +43,28 @@ DISCOVERY_RESPONSE = {
         "lock": 0,
     },
 }
+DISCOVERY_RESPONSE_NO_CID = {
+    "t": "pack",
+    "i": 1,
+    "uid": 0,
+    "cid": "",
+    "tcid": "",
+    "pack": {
+        "t": "dev",
+        "cid": "",
+        "bc": "gree",
+        "brand": "gree",
+        "catalog": "gree",
+        "mac": "aabbcc112233",
+        "mid": "10001",
+        "model": "gree",
+        "name": "fake unit",
+        "series": "gree",
+        "vender": "1",
+        "ver": "V1.1.13",
+        "lock": 0,
+    },
+}
 DEFAULT_RESPONSE = {
     "t": "pack",
     "i": 1,
@@ -182,9 +204,18 @@ async def test_broadcast_timeout(addr, bcast, family):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "addr,bcast,family", [(("127.0.0.1", 7000), "127.255.255.255", socket.AF_INET)]
+    "addr,bcast,family,dresp",
+    [
+        (("127.0.0.1", 7000), "127.255.255.255", socket.AF_INET, DISCOVERY_RESPONSE),
+        (
+            ("127.0.0.1", 7000),
+            "127.255.255.255",
+            socket.AF_INET,
+            DISCOVERY_RESPONSE_NO_CID,
+        ),
+    ],
 )
-async def test_search_on_interface(addr, bcast, family):
+async def test_search_on_interface(addr, bcast, family, dresp):
     """Create a socket broadcast responder, an async broadcast listener, test discovery responses."""
     with socket.socket(family, socket.SOCK_DGRAM) as sock:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -196,7 +227,7 @@ async def test_search_on_interface(addr, bcast, family):
             p = json.loads(d)
             assert p == DISCOVERY_REQUEST
 
-            r = DISCOVERY_RESPONSE
+            r = dresp
             r["pack"] = DatagramStream.encrypt_payload(r["pack"])
             p = json.dumps(r)
             s.sendto(p.encode(), addr)


### PR DESCRIPTION
This change introduces a bugfix addressing discovery responses that used the "mac" field instead of "cid" for the device identifier.

In this case we'll now prioritize receive the "mac" instead of "cid" and fallback to "cid" in the case that the "mac" field is null. It is not clear the the "mac" field should ever be null, and we may need to revisit the fallback behaviour in the future if device samples shows a different behaviour.

Closes #18 