### PR TITLE
Improvements to the discovery algorithm to allow for longer response times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 .DS_Store
 
 cov.xml
+
+boot.py

--- a/README.md
+++ b/README.md
@@ -27,19 +27,20 @@ The easiest way to grab **greeclimate** is through PyPI
 Scan the network for devices, select a device and immediately bind. See the notes below for caveats.
 
 ```python
-try:
-    if not self._device_key:
-        devices = await Discovery.search_devices()
-        if self._mac:
-            deviceinfo = next((d for d in devices if d.mac == self._mac), None)
-        else:
-            deviceinfo = next((d for d in devices if d.ip == self._ip), None)
-    else:
-        deviceinfo = DeviceInfo(self._ip, self._port, self._mac, self._name)
-    device = Device(deviceinfo)
-    await device.bind(key=self._device_key)
-except Exception:
-    raise CannotConnect
+for device_info in await Discovery.search_devices():
+    try:
+        device = Device(device_info)
+        await device.bind() # Device will auto bind on update if you omit this step
+    except CannotConnect:
+        _LOGGER.error("Unable to bind to gree device: %s", device_info)
+        continue
+
+    _LOGGER.debug(
+        "Adding Gree device at %s:%i (%s)",
+        device.device_info.ip,
+        device.device_info.port,
+        device.device_info.name,
+    )
 ```
 
 #### Caveats

--- a/emulator.py
+++ b/emulator.py
@@ -1,0 +1,109 @@
+"""
+Micropython device emulator, intended to run on 8266 mcus
+"""
+
+import json
+import machine
+import network
+import socket
+import time
+import ubinascii
+
+from ucryptolib import aes
+
+device_id = ubinascii.hexlify(network.WLAN().config("mac")).decode()
+device_name = device_id[-8:]
+
+GENERIC_KEY = "a3K8Bx%2r8Y7#xDh"
+DEVICE_KEY = device_id + device_id[:4]
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.bind(("0.0.0.0", 7000))
+
+print("listening on for device events")
+
+
+def send_device_data(addr, data, key):
+    """Send a formatted request to the device."""
+    print("\r\nS: ", json.dumps(data))
+
+    if "pack" in data:
+
+        def pad(s):
+            bs = 16
+            return s + (bs - len(s) % bs) * chr(bs - len(s) % bs)
+
+        cipher = aes(key, 1)
+        encrypted = cipher.encrypt(pad(json.dumps(data.get("pack")).encode()))
+        data["pack"] = ubinascii.b2a_base64(encrypted).decode()
+
+    data_bytes = json.dumps(data).encode()
+    sock.sendto(data_bytes, addr)
+
+
+def scan_response(addr):
+    resp = {
+        "t": "pack",
+        "i": 1,
+        "uid": 0,
+        "cid": device_id,
+        "tcid": "",
+        "pack": {
+            "t": "dev",
+            "cid": device_id,
+            "bc": "",
+            "brand": "gree",
+            "catalog": "gree",
+            "mac": device_id,
+            "mid": "10001",
+            "model": "gree",
+            "name": device_name,
+            "series": "gree",
+            "vender": "1",
+            "ver": "V1.2.1",
+            "lock": 0,
+        },
+    }
+    send_device_data(addr, resp, GENERIC_KEY)
+
+
+def bind_response(addr):
+    resp = {
+        "t": "pack",
+        "i": 1,
+        "uid": 0,
+        "cid": device_id,
+        "tcid": "",
+        "pack": {
+            "t": "bindok",
+            "mac": device_id,
+            "key": DEVICE_KEY,
+            "r": 200,
+        },
+    }
+    send_device_data(addr, resp, GENERIC_KEY)
+
+
+while True:
+    (d, addr) = sock.recvfrom(2048)
+    p = json.loads(d.decode())
+
+    print("\r\nR: ", d.decode())
+    command = p.get("t")
+    if command == "scan":
+        scan_response(addr)
+    elif command == "pack":
+        # Decrypt the incoming request
+        key = GENERIC_KEY if p.get("cid") == "app" else DEVICE_KEY
+        cipher = aes(key, 1)
+        decoded = ubinascii.a2b_base64(p.get("pack"))
+        decrypted = cipher.decrypt(decoded).decode()
+        fixed = decrypted.replace(decrypted[decrypted.rindex("}") + 1 :], "")
+        print("D: ", fixed)
+        data = json.loads(fixed)
+
+        command = data.get("t")
+        if command == "bind":
+            bind_response(addr)
+
+    time.sleep_ms(500)

--- a/gree.py
+++ b/gree.py
@@ -1,0 +1,37 @@
+import argparse
+import asyncio
+import logging
+
+from greeclimate.device import Device
+from greeclimate.discovery import Discovery
+
+logging.basicConfig(
+    level=logging.DEBUG, format="%(name)s - %(levelname)s - %(message)s"
+)
+_LOGGER = logging.getLogger(__name__)
+
+
+async def run_discovery():
+    devices = []
+    _LOGGER.debug("Scanning network for Gree devices")
+
+    for device_info in await Discovery.search_devices():
+        device = Device(device_info)
+        await device.bind()
+
+        _LOGGER.debug(
+            "Adding Gree device at %s:%i (%s)",
+            device.device_info.ip,
+            device.device_info.port,
+            device.device_info.name,
+        )
+        devices.append(device)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Gree command line utility.")
+    parser.add_argument("--discovery", action="store_true", default=False)
+    args = parser.parse_args()
+
+    if args.discovery:
+        asyncio.run(run_discovery())
+        

--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -191,7 +191,7 @@ class Device:
             if key:
                 self.device_key = key
             else:
-                self.device_key = await network.bind_device(self.device_info)
+                self.device_key = await network.bind_device(self.device_info, announce=True)
 
             if self.device_key:
                 self._logger.info("Bound to device using key %s", self.device_key)

--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -191,17 +191,22 @@ class Device:
             if key:
                 self.device_key = key
             else:
-                self.device_key = await network.bind_device(self.device_info, announce=True)
+                self.device_key = await network.bind_device(
+                    self.device_info, announce=True
+                )
 
             if self.device_key:
                 self._logger.info("Bound to device using key %s", self.device_key)
         except asyncio.TimeoutError:
+            pass
+
+        if not self.device_key:
             raise DeviceNotBoundError
 
     async def update_state(self):
         """ Update the internal state of the device structure of the physical device """
         if not self.device_key:
-            raise DeviceNotBoundError
+            self.bind()
 
         self._logger.debug("Updating device properties for (%s)", str(self.device_info))
 
@@ -218,6 +223,9 @@ class Device:
         """ Push any pending state updates to the unit """
         if not self._dirty:
             return
+
+        if not self.device_key:
+            self.bind()
 
         self._logger.debug("Pushing state updates to (%s)", str(self.device_info))
 

--- a/greeclimate/network.py
+++ b/greeclimate/network.py
@@ -322,8 +322,6 @@ async def send_state(property_values, device_info, key=GENERIC_KEY):
     try:
         await stream.send_device_data(payload, key)
         (r, _) = await stream.recv_device_data(key)
-    except asyncio.TimeoutError as e:
-        raise e
     except Exception as e:
         _LOGGER.debug("Encountered an error sending state to device")
         _LOGGER.debug(str(e))
@@ -351,8 +349,6 @@ async def request_state(properties, device_info, key=GENERIC_KEY):
     try:
         await stream.send_device_data(payload, key)
         (r, _) = await stream.recv_device_data(key)
-    except asyncio.TimeoutError as e:
-        raise e
     except Exception as e:
         _LOGGER.debug("Encountered an error requesting update from device")
         _LOGGER.debug(str(e))

--- a/greeclimate/network.py
+++ b/greeclimate/network.py
@@ -10,6 +10,7 @@ from typing import List, Text, Tuple, Union
 
 from Crypto.Cipher import AES
 
+NETWORK_TIMEOUT = 10
 GENERIC_KEY = "a3K8Bx%2r8Y7#xDh"
 
 _LOGGER = logging.getLogger(__name__)
@@ -240,7 +241,7 @@ async def search_on_interface(bcast_iface: IPInterface, timeout: int):
     return devices
 
 
-async def search_devices(timeout: int = 2, broadcastAddrs: str = None):
+async def search_devices(timeout: int = NETWORK_TIMEOUT, broadcastAddrs: str = None):
     if not broadcastAddrs:
         broadcastAddrs = get_broadcast_addresses()
 
@@ -267,7 +268,7 @@ async def create_datagram_stream(target: IPAddr) -> DatagramStream:
     transport, _ = await loop.create_datagram_endpoint(
         lambda: DeviceProtocol(recvq, excq, drained), remote_addr=target
     )
-    return DatagramStream(transport, recvq, excq, drained, timeout=10)
+    return DatagramStream(transport, recvq, excq, drained, timeout=NETWORK_TIMEOUT)
 
 
 async def bind_device(device_info, announce=False):

--- a/greeclimate/network.py
+++ b/greeclimate/network.py
@@ -152,7 +152,7 @@ class DatagramStream:
         cipher = AES.new(key.encode(), AES.MODE_ECB)
         decoded = base64.b64decode(payload)
         decrypted = cipher.decrypt(decoded).decode()
-        t = decrypted.replace(decrypted[decrypted.rindex("}") + 1 :], "")
+        t = decrypted.replace(decrypted[decrypted.rindex("}") + 1:], "")
         return json.loads(t)
 
     @staticmethod
@@ -270,7 +270,7 @@ async def create_datagram_stream(target: IPAddr) -> DatagramStream:
     return DatagramStream(transport, recvq, excq, drained, timeout=10)
 
 
-async def bind_device(device_info):
+async def bind_device(device_info, announce=False):
     payload = {
         "cid": "app",
         "i": "1",
@@ -284,6 +284,9 @@ async def bind_device(device_info):
     stream = await create_datagram_stream(remote_addr)
     try:
         # Binding uses the generic key only
+        if announce:
+            await stream.send_device_data({"t": "scan"})
+            await stream.recv_device_data()
         await stream.send_device_data(payload)
         (r, _) = await stream.recv_device_data()
     except asyncio.TimeoutError as e:


### PR DESCRIPTION
A few issues reporting unreliable discovery of devices on homeassistant makes me believe that there is a general issue with the disovery-bind sequences being too fast for some devices & setups. The issue though is that binding must follow the discovery phase shortly afterwards or it can also fail, but we need enough time to allow discovery responses on a congested network. This change allows for deferred binding to device, uses a direct (non-broadcast) discovery packet on bind, and moves to a 10 second timeout for discovery responses.

This should help provide a more robust implementation for finnicky devices and unreliable setups.