### PR TITLE
Refactor discovery to support async callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The easiest way to grab **greeclimate** is through PyPI
 Scan the network for devices, select a device and immediately bind. See the notes below for caveats.
 
 ```python
-for device_info in await Discovery.search_devices():
+for device_info, _ in await Discovery.search_devices():
     try:
         device = Device(device_info)
         await device.bind() # Device will auto bind on update if you omit this step

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The easiest way to grab **greeclimate** is through PyPI
 Scan the network for devices, select a device and immediately bind. See the notes below for caveats.
 
 ```python
-for device_info, _ in await Discovery.search_devices():
+discovery = Discovery()
+for device_info in await discovery.scan(wait_for=5):
     try:
         device = Device(device_info)
         await device.bind() # Device will auto bind on update if you omit this step

--- a/emulator.py
+++ b/emulator.py
@@ -3,12 +3,12 @@ Micropython device emulator, intended to run on 8266 mcus
 """
 
 import json
-import machine
-import network
 import socket
 import time
-import ubinascii
 
+import machine
+import network
+import ubinascii
 from ucryptolib import aes
 
 device_id = ubinascii.hexlify(network.WLAN().config("mac")).decode()

--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -90,14 +90,6 @@ class DeviceInfo:
         name: Name of unit, if available
     """
 
-    ip = None
-    port = None
-    mac = None
-    name = "<No Name>"
-    brand = None
-    model = None
-    version = None
-
     def __init__(self, ip, port, mac, name, brand=None, model=None, version=None):
         self.ip = ip
         self.port = port
@@ -210,7 +202,7 @@ class Device:
     async def update_state(self):
         """ Update the internal state of the device structure of the physical device """
         if not self.device_key:
-            self.bind()
+            await self.bind()
 
         self._logger.debug("Updating device properties for (%s)", str(self.device_info))
 
@@ -229,7 +221,7 @@ class Device:
             return
 
         if not self.device_key:
-            self.bind()
+            await self.bind()
 
         self._logger.debug("Pushing state updates to (%s)", str(self.device_info))
 

--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -178,6 +178,10 @@ class Device:
 
             Both approaches result in a device_key which is used as like a persitent session id.
 
+        Args:
+            key (str): The device key, when provided binding is a NOOP, if None binding will
+                       attempt to negatiate the key with the device.
+
         Raises:
             DeviceNotBoundError: If binding was unsuccessful (the device didn't respond.)
         """

--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -183,7 +183,8 @@ class Device:
                        attempt to negatiate the key with the device.
 
         Raises:
-            DeviceNotBoundError: If binding was unsuccessful (the device didn't respond.)
+            DeviceNotBoundError: If binding was unsuccessful and no key returned
+            DeviceTimeoutError: The device didn't respond
         """
 
         if not self.device_info:
@@ -198,14 +199,13 @@ class Device:
                 self.device_key = await network.bind_device(
                     self.device_info, announce=False
                 )
-
-            if self.device_key:
-                self._logger.info("Bound to device using key %s", self.device_key)
         except asyncio.TimeoutError:
-            pass
+            raise DeviceTimeoutError
 
         if not self.device_key:
             raise DeviceNotBoundError
+        else:
+            self._logger.info("Bound to device using key %s", self.device_key)
 
     async def update_state(self):
         """ Update the internal state of the device structure of the physical device """

--- a/greeclimate/discovery.py
+++ b/greeclimate/discovery.py
@@ -162,6 +162,7 @@ class Discovery(BroadcastListenerProtocol, Listener):
         await self.search_devices()
         if wait_for:
             await asyncio.sleep(wait_for)
+            await asyncio.gather(*self.tasks, return_exceptions=True)
 
         return self._device_infos
 

--- a/greeclimate/discovery.py
+++ b/greeclimate/discovery.py
@@ -2,54 +2,168 @@ import asyncio
 import json
 import logging
 import time
-
+from asyncio import Task
+from asyncio.events import AbstractEventLoop
 from ipaddress import IPv4Network
-from typing import Coroutine, List, Tuple
+from typing import Coroutine, List
 
-from greeclimate.network import BroadcastListenerProtocol, DatagramStream, IPInterface
 from greeclimate.device import DeviceInfo
+from greeclimate.network import BroadcastListenerProtocol, IPAddr, IPInterface
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class Discovery:
+class Listener:
+    """Base class for device discovery events."""
+
+    async def device_found(self, device_info: DeviceInfo) -> None:
+        """Called any time a new (unique) device is found on the network."""
+
+
+class Discovery(BroadcastListenerProtocol, Listener):
     """Interact with gree devices on the network
 
     The `GreeClimate` class provides basic services for discovery and
     interaction with gree device on the network.
     """
 
-    def __init__(self, timeout: int = 10, allow_loopback: bool = False):
+    def __init__(
+        self,
+        timeout: int = 2,
+        allow_loopback: bool = False,
+        loop: AbstractEventLoop = None,
+    ):
         """Intialized the discovery manager.
 
         Args:
             timeout (int): Wait this long for responses to the scan request
+            allow_loopback (bool): Allow scanning the loopback interface, default `False`
+            loop (AbstractEventLoop): Async event loop
         """
+        super(BroadcastListenerProtocol, self).__init__()
         self._timeout = timeout
         self._allow_loopback = allow_loopback
-        self._iface_streams = {}
-        self._cbs = []
 
-    async def search_devices(
-        self, async_callback: Coroutine = None
-    ) -> Tuple[List[DeviceInfo], List[Coroutine]]:
+        self._device_infos = []
+        self._listeners = []
+        self._tasks = []
+
+        self._loop = loop or asyncio.get_event_loop()
+        self._transport = None
+
+    # Task management
+    @property
+    def tasks(self) -> List[Coroutine]:
+        """Returns the outstanding tasks waiting completion."""
+        return self._tasks
+
+    @property
+    def devices(self) -> List[DeviceInfo]:
+        """Return the current known list of devices."""
+        return self._device_infos
+
+    def _task_done_callback(self, task):
+        if task.exception():
+            _LOGGER.exception("Uncaught exception", exc_info=task.exception())
+        self._tasks.remove(task)
+
+    def _create_task(self, coro) -> Task:
+        """Create and track tasks that are being created for events."""
+        task = self._loop.create_task(coro)
+        self._tasks.append(task)
+        task.add_done_callback(self._task_done_callback)
+        return task
+
+    # Listener management
+    def add_listener(self, listener: Listener) -> List[Coroutine]:
+        """Add a listener that will receive discovery events.
+
+        Adding a listener will cause all currently known device to trigger a
+        new device added event on the listen object.
+
+        Args:
+            listener (Listener): A listener object which will receive events
+
+        Returns:
+            List[Coro]: List of tasks for device found events.
+        """
+        if not listener in self._listeners:
+            self._listeners.append(listener)
+            return [self._create_task(listener.device_found(x)) for x in self.devices]
+
+    def remove_listener(self, listener: Listener) -> bool:
+        """Remove a listener that has already been registered.
+
+        Args:
+            listener (Listener): A listener object which will receive events
+
+        Returns:
+            bool: True if listener has been remove, false if it didn't exist
+        """
+        if listener in self._listeners:
+            self._listeners.remove(listener)
+            return True
+        return False
+
+    async def device_found(self, device_info: DeviceInfo) -> None:
+        """Device is found.
+
+        Notify all listeners that a device was found. Exceptions raised by
+        listeners are ignored.
+
+        Args:
+            device_info (DeviceInfo): Information about the newly discovered
+            device
+        """
+
+        if device_info in self._device_infos:
+            return
+
+        self._device_infos.append(device_info)
+
+        _LOGGER.info("Found gree device %s", str(device_info))
+
+        tasks = [l.device_found(device_info) for l in self._listeners]
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    def packet_received(self, obj, addr: IPAddr) -> None:
+        """Event called when a packet is received and decoded."""
+        pack = obj.get("pack")
+        if not pack:
+            _LOGGER.error("Received an unexpected response during discovery")
+            return
+
+        device = (
+            addr[0],
+            addr[1],
+            pack.get("mac") or pack.get("cid"),
+            pack.get("name"),
+            pack.get("brand"),
+            pack.get("model"),
+            pack.get("ver"),
+        )
+
+        self._create_task(self.device_found(DeviceInfo(*device)))
+
+    # Discovery
+    async def scan(self, wait_for=0) -> List[DeviceInfo]:
         """Sends a discovery broadcast packet on each network interface to
             locate Gree units on the network
 
         Args:
-            async_callback (coro): Called as soon as a device is located on the network
+            wait_for (int): Optionally wait this many seconds for discovery
+                            and return the devices found.
 
         Returns:
-            List[DeviceInfo]: List of device informations for each device found
-            List[Coroutine]: List of callback tasks
+            List[DeviceInfo]: List of devices found during this scan
         """
-        _LOGGER.info("Locating Gree devices ...")
+        _LOGGER.info("Scanning for Gree devices ...")
 
-        self._cbs = []
-        results = await self._search_devices(async_callback=async_callback)
-        devices = [DeviceInfo(*d) for d in list(set(results))]
+        await self.search_devices()
+        if wait_for:
+            await asyncio.sleep(wait_for)
 
-        return devices, self._cbs
+        return self._device_infos
 
     def _get_broadcast_addresses(self) -> List[IPInterface]:
         """ Return a list of broadcast addresses for each discovered interface"""
@@ -73,89 +187,25 @@ class Discovery:
 
         return broadcastAddrs
 
-    async def _search_on_interface(
-        self, bcast_iface: IPInterface, async_callback: Coroutine
-    ):
+    async def search_on_interface(self, bcast_iface: IPInterface) -> None:
+        """Search for devices on a specific interface."""
         _LOGGER.debug("Listening for devices on %s", bcast_iface.ip_address)
 
-        if self._iface_streams.get(bcast_iface.ip_address) is None:
-            loop = asyncio.get_event_loop()
-            recvq = asyncio.Queue()
-            excq = asyncio.Queue()
-            drained = asyncio.Event()
-
+        if self._transport is None:
             local_addr = (bcast_iface.ip_address, 0)
 
-            transport, _ = await loop.create_datagram_endpoint(
-                lambda: BroadcastListenerProtocol(recvq, excq, drained),
-                local_addr=local_addr,
-                allow_broadcast=True,
-            )
-            self._iface_streams[bcast_iface.ip_address] = DatagramStream(
-                transport, recvq, excq, drained, self._timeout
+            self._transport, _ = await self._loop.create_datagram_endpoint(
+                lambda: self, local_addr=local_addr, allow_broadcast=True
             )
 
-        stream = self._iface_streams[bcast_iface.ip_address]
-        data = json.dumps({"t": "scan"}).encode()
-        await stream.send(data, (bcast_iface.bcast_address, 7000))
+        await self.send({"t": "scan"}, (bcast_iface.bcast_address, 7000))
 
-        devices = []
-
-        start_ts = time.time()
-        loop_ts = start_ts + self._timeout
-        while loop_ts > time.time() or stream.recv_ready():
-            if not stream.recv_ready():
-                dt = loop_ts - time.time()
-                dt = min(dt, 1)
-                await asyncio.sleep(dt)
-                continue
-
-            try:
-                (response, addr) = await stream.recv_device_data()
-                pack = response["pack"]
-                _LOGGER.debug("Received response from device search\n%s", pack)
-                device = (
-                    addr[0],
-                    addr[1],
-                    pack.get("mac") or pack.get("cid"),
-                    pack.get("name"),
-                    pack.get("brand"),
-                    pack.get("model"),
-                    pack.get("ver"),
-                )
-
-                if async_callback:
-                    self._cbs.append(
-                        asyncio.create_task(async_callback(DeviceInfo(*device)))
-                    )
-
-                _LOGGER.info("Found %s", str(DeviceInfo(*device)))
-                devices.append(device)
-            except asyncio.TimeoutError:
-                break
-            except json.JSONDecodeError:
-                _LOGGER.debug("Unable to decode device search response payload")
-
-        return devices
-
-    async def _search_devices(
-        self, broadcastAddrs: str = None, async_callback: Coroutine = None
-    ):
+    async def search_devices(self, broadcastAddrs: str = None) -> None:
+        """Search for devices with specific broadcast addresses."""
         if not broadcastAddrs:
             broadcastAddrs = self._get_broadcast_addresses()
 
         broadcastAddrs = list(broadcastAddrs)
-        done, _ = await asyncio.wait(
-            [
-                asyncio.create_task(self._search_on_interface(b, async_callback))
-                for b in broadcastAddrs
-            ]
+        await asyncio.gather(
+            *[asyncio.create_task(self.search_on_interface(b)) for b in broadcastAddrs]
         )
-
-        devices = []
-        for task in done:
-            results = task.result()
-            for result in results:
-                devices.append(result)
-
-        return devices

--- a/greeclimate/discovery.py
+++ b/greeclimate/discovery.py
@@ -1,7 +1,12 @@
+import asyncio
+import json
 import logging
-from typing import List
+import time
 
-import greeclimate.network as nethelper
+from ipaddress import IPv4Network
+from typing import Coroutine, List
+
+from greeclimate.network import BroadcastListenerProtocol, DatagramStream, IPInterface
 from greeclimate.device import DeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
@@ -10,23 +15,142 @@ _LOGGER = logging.getLogger(__name__)
 class Discovery:
     """Interact with gree devices on the network
 
-    The `GreeClimate` class provides basic services for discovery and interaction
-    with gree device on the network.
+    The `GreeClimate` class provides basic services for discovery and
+    interaction with gree device on the network.
     """
 
-    @staticmethod
-    async def search_devices(timeout=10) -> List[DeviceInfo]:
+    def __init__(self, timeout: int = 10, allow_loopback: bool = False):
+        """Intialized the discovery manager.
+
+        Args:
+            timeout (int): Wait this long for responses to the scan request
+        """
+        self._timeout = timeout
+        self._allow_loopback = allow_loopback
+        self._iface_streams = {}
+
+    async def search_devices(
+        self, async_callback: Coroutine = None
+    ) -> List[DeviceInfo]:
         """Sends a discovery broadcast packet on each network interface to
             locate Gree units on the network
 
-        Returns:
-            List[DeviceInfo]: List of device informations
-        """
-        _LOGGER.info("Starting Gree device discovery process")
+        Args:
+            async_callback (coro): Called as soon as a device is located on the network
 
-        results = await nethelper.search_devices(timeout=timeout)
+        Returns:
+            List[DeviceInfo]: List of device informations for each device found
+        """
+        _LOGGER.info("Locating Gree devices ...")
+
+        results = await self._search_devices(async_callback=async_callback)
         devices = [DeviceInfo(*d) for d in list(set(results))]
-        for d in devices:
-            _LOGGER.info("Found %s", str(d))
+
+        return devices
+
+    def _get_broadcast_addresses(self) -> List[IPInterface]:
+        """ Return a list of broadcast addresses for each discovered interface"""
+        import netifaces
+
+        broadcastAddrs = []
+
+        interfaces = netifaces.interfaces()
+        for iface in interfaces:
+            addr = netifaces.ifaddresses(iface)
+            if netifaces.AF_INET in addr:
+                netmask = addr[netifaces.AF_INET][0].get("netmask")
+                ipaddr = addr[netifaces.AF_INET][0].get("addr")
+                if netmask and addr:
+                    net = IPv4Network(f"{ipaddr}/{netmask}", strict=False)
+                    if net.broadcast_address:
+                        if not net.is_loopback or self._allow_loopback:
+                            broadcastAddrs.append(
+                                IPInterface(str(ipaddr), str(net.broadcast_address))
+                            )
+
+        return broadcastAddrs
+
+    async def _search_on_interface(
+        self, bcast_iface: IPInterface, async_callback: Coroutine
+    ):
+        _LOGGER.debug("Listening for devices on %s", bcast_iface.ip_address)
+
+        if self._iface_streams.get(bcast_iface.ip_address) is None:
+            loop = asyncio.get_event_loop()
+            recvq = asyncio.Queue()
+            excq = asyncio.Queue()
+            drained = asyncio.Event()
+
+            local_addr = (bcast_iface.ip_address, 0)
+
+            transport, _ = await loop.create_datagram_endpoint(
+                lambda: BroadcastListenerProtocol(recvq, excq, drained),
+                local_addr=local_addr,
+                allow_broadcast=True,
+            )
+            self._iface_streams[bcast_iface.ip_address] = DatagramStream(
+                transport, recvq, excq, drained, self._timeout
+            )
+
+        stream = self._iface_streams[bcast_iface.ip_address]
+        data = json.dumps({"t": "scan"}).encode()
+        await stream.send(data, ("255.255.255.255", 7000))
+
+        devices = []
+
+        start_ts = time.time()
+        loop_ts = start_ts + self._timeout
+        while loop_ts > time.time() or stream.recv_ready():
+            if not stream.recv_ready():
+                dt = loop_ts - time.time()
+                dt = min(dt, 1)
+                await asyncio.sleep(dt)
+                continue
+
+            try:
+                (response, addr) = await stream.recv_device_data()
+                pack = response["pack"]
+                _LOGGER.debug("Received response from device search\n%s", pack)
+                device = (
+                    addr[0],
+                    addr[1],
+                    pack.get("mac") or pack.get("cid"),
+                    pack.get("name"),
+                    pack.get("brand"),
+                    pack.get("model"),
+                    pack.get("ver"),
+                )
+
+                if async_callback:
+                    asyncio.create_task(async_callback(DeviceInfo(*device)))
+
+                _LOGGER.info("Found %s", str(DeviceInfo(*device)))
+                devices.append(device)
+            except asyncio.TimeoutError:
+                break
+            except json.JSONDecodeError:
+                _LOGGER.debug("Unable to decode device search response payload")
+
+        return devices
+
+    async def _search_devices(
+        self, broadcastAddrs: str = None, async_callback: Coroutine = None
+    ):
+        if not broadcastAddrs:
+            broadcastAddrs = self._get_broadcast_addresses()
+
+        broadcastAddrs = list(broadcastAddrs)
+        done, _ = await asyncio.wait(
+            [
+                asyncio.create_task(self._search_on_interface(b, async_callback))
+                for b in broadcastAddrs
+            ]
+        )
+
+        devices = []
+        for task in done:
+            results = task.result()
+            for result in results:
+                devices.append(result)
 
         return devices

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,71 @@
+import asyncio
+import socket
+
+from unittest.mock import Mock, create_autospec, patch
+
+DEFAULT_TIMEOUT = 5
+DISCOVERY_REQUEST = {"t": "scan"}
+DISCOVERY_RESPONSE = {
+    "t": "pack",
+    "i": 1,
+    "uid": 0,
+    "cid": "aabbcc112233",
+    "tcid": "",
+    "pack": {
+        "t": "dev",
+        "cid": "aabbcc112233",
+        "bc": "gree",
+        "brand": "gree",
+        "catalog": "gree",
+        "mac": "aabbcc112233",
+        "mid": "10001",
+        "model": "gree",
+        "name": "fake unit",
+        "series": "gree",
+        "vender": "1",
+        "ver": "V1.1.13",
+        "lock": 0,
+    },
+}
+DISCOVERY_RESPONSE_NO_CID = {
+    "t": "pack",
+    "i": 1,
+    "uid": 0,
+    "cid": "",
+    "tcid": "",
+    "pack": {
+        "t": "dev",
+        "cid": "",
+        "bc": "gree",
+        "brand": "gree",
+        "catalog": "gree",
+        "mac": "aabbcc112233",
+        "mid": "10001",
+        "model": "gree",
+        "name": "fake unit",
+        "series": "gree",
+        "vender": "1",
+        "ver": "V1.1.13",
+        "lock": 0,
+    },
+}
+DEFAULT_RESPONSE = {
+    "t": "pack",
+    "i": 1,
+    "uid": 0,
+    "cid": "aabbcc112233",
+    "tcid": "",
+    "pack": {},
+}
+
+
+def get_mock_device_info():
+    return Mock(
+        name="device-info",
+        ip="127.0.0.1",
+        port="7000",
+        mac="aabbcc112233",
+        brand="gree",
+        model="gree",
+        version="1.1.13",
+    )

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,7 +1,9 @@
 import asyncio
 import socket
-
+from socket import SOCK_DGRAM
 from unittest.mock import Mock, create_autospec, patch
+
+from greeclimate.network import DeviceProtocol2
 
 DEFAULT_TIMEOUT = 5
 DISCOVERY_REQUEST = {"t": "scan"}
@@ -69,3 +71,33 @@ def get_mock_device_info():
         model="gree",
         version="1.1.13",
     )
+
+
+def encrypt_payload(data):
+    """Encrypt the payload of responses quickly."""
+    d = data.copy()
+    d["pack"] = DeviceProtocol2.encrypt_payload(d["pack"])
+    return d
+
+
+class Responder:
+    """Context manage for easy raw socket responders."""
+
+    def __init__(self, family, addr) -> None:
+        """Initialize the class."""
+        self.sock = None
+        self.family = family
+        self.addr = addr
+
+    def __enter__(self):
+        """Enter the context manager."""
+        self.sock = socket.socket(self.family, SOCK_DGRAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        self.sock.settimeout(DEFAULT_TIMEOUT)
+        self.sock.bind(("", self.addr))
+        return self.sock
+
+    def __exit__(self, *args):
+        """Exit the context manager."""
+        self.sock.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest module configuration."""
+import pytest
+from unittest.mock import patch
+
+MOCK_INTERFACES = ["lo"]
+MOCK_LO_IFACE = {
+    2: [{"addr": "10.0.0.1", "netmask": "255.0.0.0", "peer": "10.255.255.255"}]
+}
+
+
+@pytest.fixture(name="netifaces")
+def netifaces_fixture():
+    """Patch netifaces interface discover."""
+    with patch("netifaces.interfaces", return_value=MOCK_INTERFACES), patch(
+        "netifaces.ifaddresses", return_value=MOCK_LO_IFACE
+    ) as ifaddr_mock:
+        yield ifaddr_mock
+
+
+@pytest.fixture(name="search_devices")
+def search_devices_fixture():
+    """Patch search_on_interface."""
+    with patch("greeclimate.discovery.Discovery._search_devices") as mock:
+        yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Pytest module configuration."""
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 MOCK_INTERFACES = ["lo"]
 MOCK_LO_IFACE = {
@@ -15,10 +16,3 @@ def netifaces_fixture():
         "netifaces.ifaddresses", return_value=MOCK_LO_IFACE
     ) as ifaddr_mock:
         yield ifaddr_mock
-
-
-@pytest.fixture(name="search_devices")
-def search_devices_fixture():
-    """Patch search_on_interface."""
-    with patch("greeclimate.discovery.Discovery._search_devices") as mock:
-        yield mock

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -112,9 +112,8 @@ def test_device_info_equality():
 
 
 @pytest.mark.asyncio
-@patch("greeclimate.network.search_devices")
 @patch("greeclimate.network.bind_device")
-async def test_get_device_info(mock_bind, mock_search):
+async def test_get_device_info(mock_bind, search_devices):
     # DeviceInfo("192.168.1.29", 7000, "f4911e7aca59", "1e7aca59")
 
     mock_info = (
@@ -126,12 +125,14 @@ async def test_get_device_info(mock_bind, mock_search):
         "MockModel",
         "0.0.1-fake",
     )
-    mock_search.return_value = [mock_info]
+
+    search_devices.return_value = [mock_info]
     mock_bind.return_value = "St8Vw1Yz4Bc7Ef0H"
 
     """ The only way to get the key through binding is by scanning first
     """
-    devices = await Discovery.search_devices()
+    discovery = Discovery(allow_loopback=True)
+    devices = await discovery.search_devices()
     device = Device(devices[0])
     await device.bind()
 
@@ -151,16 +152,16 @@ async def test_get_device_info(mock_bind, mock_search):
 
 
 @pytest.mark.asyncio
-@patch("greeclimate.network.search_devices")
 @patch("greeclimate.network.bind_device")
-async def test_get_device_key_timeout(mock_bind, mock_search):
+async def test_get_device_key_timeout(mock_bind, search_devices):
 
-    mock_search.return_value = [("1.1.1.0", "7000", "aabbcc001122", "MockDevice1")]
+    search_devices.return_value = [("1.1.1.0", "7000", "aabbcc001122", "MockDevice1")]
     mock_bind.side_effect = asyncio.TimeoutError
 
     """ The only way to get the key through binding is by scanning first
     """
-    devices = await Discovery.search_devices()
+    discovery = Discovery(allow_loopback=True)
+    devices = await discovery.search_devices()
     device = Device(devices[0])
 
     with pytest.raises(DeviceNotBoundError):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -132,7 +132,7 @@ async def test_get_device_info(mock_bind, search_devices):
     """ The only way to get the key through binding is by scanning first
     """
     discovery = Discovery(allow_loopback=True)
-    devices = await discovery.search_devices()
+    devices, _ = await discovery.search_devices()
     device = Device(devices[0])
     await device.bind()
 
@@ -164,7 +164,7 @@ async def test_get_device_key_timeout(mock_bind, search_devices):
     devices = await discovery.search_devices()
     device = Device(devices[0])
 
-    with pytest.raises(DeviceNotBoundError):
+    with pytest.raises(DeviceTimeoutError):
         await device.bind()
 
     assert device is not None

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -13,6 +13,18 @@ class FakeProps(enum.Enum):
     FAKE = "fake"
 
 
+def get_mock_info():
+    return (
+        "1.1.1.0",
+        "7000",
+        "aabbcc001122",
+        "MockDevice1",
+        "MockBrand",
+        "MockModel",
+        "0.0.1-fake",
+    )
+
+
 def get_mock_state():
     return {
         "Pow": 1,
@@ -113,67 +125,101 @@ def test_device_info_equality():
 
 @pytest.mark.asyncio
 @patch("greeclimate.network.bind_device")
-async def test_get_device_info(mock_bind, search_devices):
-    # DeviceInfo("192.168.1.29", 7000, "f4911e7aca59", "1e7aca59")
+async def test_get_device_info(mock_bind):
+    """Initialize device, check properties."""
 
-    mock_info = (
-        "1.1.1.0",
-        "7000",
-        "aabbcc001122",
-        "MockDevice1",
-        "MockBrand",
-        "MockModel",
-        "0.0.1-fake",
-    )
+    info = DeviceInfo(*get_mock_info())
+    device = Device(info)
 
-    search_devices.return_value = [mock_info]
-    mock_bind.return_value = "St8Vw1Yz4Bc7Ef0H"
+    assert device.device_info == info
 
-    """ The only way to get the key through binding is by scanning first
-    """
-    discovery = Discovery(allow_loopback=True)
-    devices, _ = await discovery.search_devices()
-    device = Device(devices[0])
-    await device.bind()
+    fake_key = "abcdefgh12345678"
+    await device.bind(key=fake_key)
 
-    assert devices is not None
-    assert len(devices) == 1
-
-    assert devices[0].ip == mock_info[0]
-    assert devices[0].port == mock_info[1]
-    assert devices[0].mac == mock_info[2]
-    assert devices[0].name == mock_info[3]
-    assert devices[0].brand == mock_info[4]
-    assert devices[0].model == mock_info[5]
-    assert devices[0].version == mock_info[6]
-
-    assert device is not None
-    assert device.device_key == "St8Vw1Yz4Bc7Ef0H"
+    assert device.device_key == fake_key
 
 
 @pytest.mark.asyncio
 @patch("greeclimate.network.bind_device")
-async def test_get_device_key_timeout(mock_bind, search_devices):
+async def test_device_bind(mock_bind):
+    """Check that the device returns a device key when binding."""
 
-    search_devices.return_value = [("1.1.1.0", "7000", "aabbcc001122", "MockDevice1")]
+    info = DeviceInfo(*get_mock_info())
+    device = Device(info)
+
+    assert device.device_info == info
+
+    fake_key = "abcdefgh12345678"
+    mock_bind.return_value = fake_key
+    await device.bind()
+
+    assert device.device_key == fake_key
+
+
+@pytest.mark.asyncio
+@patch("greeclimate.network.bind_device")
+async def test_device_bind_timeout(mock_bind):
+    """Check that the device handles timeout errors when binding."""
+
+    info = DeviceInfo(*get_mock_info())
+    device = Device(info)
+
+    assert device.device_info == info
+
     mock_bind.side_effect = asyncio.TimeoutError
-
-    """ The only way to get the key through binding is by scanning first
-    """
-    discovery = Discovery(allow_loopback=True)
-    devices = await discovery.search_devices()
-    device = Device(devices[0])
 
     with pytest.raises(DeviceTimeoutError):
         await device.bind()
 
-    assert device is not None
     assert device.device_key is None
+
+
+@pytest.mark.asyncio
+@patch("greeclimate.network.bind_device")
+async def test_device_bind_none(mock_bind):
+    """Check that the device handles bad binding sequences."""
+
+    info = DeviceInfo(*get_mock_info())
+    device = Device(info)
+
+    assert device.device_info == info
+
+    mock_bind.return_value = None
+
+    with pytest.raises(DeviceNotBoundError):
+        await device.bind()
+
+    assert device.device_key is None
+
+
+@pytest.mark.asyncio
+@patch("greeclimate.network.bind_device")
+@patch("greeclimate.network.request_state")
+@patch("greeclimate.network.send_state")
+async def test_device_late_bind(mock_push, mock_update, mock_bind):
+    """Check that the device handles late binding sequences."""
+    fake_key = "abcdefgh12345678"
+    mock_bind.return_value = fake_key
+    mock_update.return_value = []
+    mock_push.return_value = []
+
+    info = DeviceInfo(*get_mock_info())
+    device = Device(info)
+    assert device.device_info == info
+
+    await device.update_state()
+    assert device.device_key == fake_key
+
+    device.device_key = None
+    device.power = True
+    await device.push_state_update()
+    assert device.device_key == fake_key
 
 
 @pytest.mark.asyncio
 @patch("greeclimate.network.request_state")
 async def test_update_properties(mock_request):
+    """Check that properties can be updates."""
     mock_request.return_value = get_mock_state()
     device = await generate_device_mock_async()
 
@@ -190,6 +236,7 @@ async def test_update_properties(mock_request):
 @pytest.mark.asyncio
 @patch("greeclimate.network.request_state", side_effect=asyncio.TimeoutError)
 async def test_update_properties_timeout(mock_request):
+    """Check that timeouts are handled when properties are updates."""
     mock_request.return_value = get_mock_state()
     device = await generate_device_mock_async()
 
@@ -202,7 +249,19 @@ async def test_update_properties_timeout(mock_request):
 
 @pytest.mark.asyncio
 @patch("greeclimate.network.send_state")
+async def test_set_properties_not_dirty(mock_request):
+    """Check that teh state isn't pushed when properties unchanged."""
+    device = await generate_device_mock_async()
+
+    await device.push_state_update()
+
+    assert mock_request.call_count == 0
+
+
+@pytest.mark.asyncio
+@patch("greeclimate.network.send_state")
 async def test_set_properties(mock_request):
+    """Check that state is pushed when properties are updated."""
     device = await generate_device_mock_async()
 
     for p in Props:
@@ -238,6 +297,7 @@ async def test_set_properties(mock_request):
 @pytest.mark.asyncio
 @patch("greeclimate.network.send_state", side_effect=asyncio.TimeoutError)
 async def test_set_properties_timeout(mock_request):
+    """Check timeout handling when pushing state changes."""
     device = await generate_device_mock_async()
 
     for p in Props:
@@ -266,6 +326,7 @@ async def test_set_properties_timeout(mock_request):
 
 @pytest.mark.asyncio
 async def test_uninitialized_properties():
+    """Check uninitialized property handling."""
     device = await generate_device_mock_async()
 
     for p in Props:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -32,7 +32,7 @@ async def test_discover_device(netifaces, search_devices):
     search_devices.return_value = [("1.1.1.0", "7000", "aabbcc001122", "MockDevice1")]
 
     discovery = discovery = Discovery(allow_loopback=True)
-    devices = await discovery.search_devices()
+    devices, _ = await discovery.search_devices()
 
     assert devices is not None
     assert len(devices) > 0
@@ -43,7 +43,7 @@ async def test_discover_no_devices(netifaces, search_devices):
     search_devices.return_value = []
 
     discovery = discovery = Discovery(allow_loopback=True)
-    devices = await discovery.search_devices()
+    devices, _ = await discovery.search_devices()
 
     assert devices is not None
     assert len(devices) == 0
@@ -58,7 +58,7 @@ async def test_discover_deduplicate_multiple_discoveries(netifaces, search_devic
     ]
 
     discovery = discovery = Discovery(allow_loopback=True)
-    devices = await discovery.search_devices()
+    devices, _ = await discovery.search_devices()
 
     assert devices is not None
     assert len(devices) == 2
@@ -99,7 +99,7 @@ async def test_discovery_callback(netifaces, addr, bcast, family):
             assert device_info is not None
 
         discovery = discovery = Discovery(allow_loopback=True)
-        devices = await discovery.search_devices(async_callback=cb)
+        devices, _ = await discovery.search_devices(async_callback=cb)
         done, _ = await asyncio.wait([fut], timeout=12)
 
         assert devices is not None
@@ -150,7 +150,7 @@ async def test_search_devices(netifaces, addr, bcast, family, dresp):
 
         # Run the listener portion now
         discovery = discovery = Discovery(allow_loopback=True)
-        response = await discovery.search_devices()
+        response, _ = await discovery.search_devices()
 
         assert response
         assert len(response) == 1
@@ -188,7 +188,7 @@ async def test_search_devices_bad_data(netifaces, addr, bcast, family):
 
         # Run the listener portion now
         discovery = discovery = Discovery(allow_loopback=True)
-        response = await discovery.search_devices()
+        response, _ = await discovery.search_devices()
 
         assert response is not None
         assert len(response) == 0
@@ -208,7 +208,7 @@ async def test_search_devices_timeout(netifaces, addr, bcast, family):
 
     # Run the listener portion now
     discovery = discovery = Discovery(allow_loopback=True)
-    response = await discovery.search_devices()
+    response, _ = await discovery.search_devices()
 
     assert response is not None
     assert len(response) == 0

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,44 +1,214 @@
-from unittest.mock import patch
-
+import asyncio
+import json
 import pytest
+import socket
+
+from threading import Thread
+from unittest.mock import create_autospec
 
 from greeclimate.discovery import Discovery
+from greeclimate.device import DeviceInfo
+from greeclimate.network import DatagramStream
+
+from .common import (
+    DEFAULT_TIMEOUT,
+    DISCOVERY_REQUEST,
+    DISCOVERY_RESPONSE,
+    DISCOVERY_RESPONSE_NO_CID,
+)
+
+
+@pytest.fixture
+def mock_socket():
+    s = create_autospec(socket.socket)
+    s.family = socket.AF_INET
+    s.type = socket.SOCK_DGRAM
+
+    return s
 
 
 @pytest.mark.asyncio
-@patch("greeclimate.network.search_devices")
-async def test_discover_device(mock_search_devices):
-    mock_search_devices.return_value = [
-        ("1.1.1.0", "7000", "aabbcc001122", "MockDevice1")
-    ]
+async def test_discover_device(netifaces, search_devices):
+    search_devices.return_value = [("1.1.1.0", "7000", "aabbcc001122", "MockDevice1")]
 
-    devices = await Discovery.search_devices()
+    discovery = discovery = Discovery(allow_loopback=True)
+    devices = await discovery.search_devices()
 
     assert devices is not None
     assert len(devices) > 0
 
 
 @pytest.mark.asyncio
-@patch("greeclimate.network.search_devices")
-async def test_discover_no_devices(mock_search_devices):
-    mock_search_devices.return_value = []
+async def test_discover_no_devices(netifaces, search_devices):
+    search_devices.return_value = []
 
-    devices = await Discovery.search_devices()
+    discovery = discovery = Discovery(allow_loopback=True)
+    devices = await discovery.search_devices()
 
     assert devices is not None
     assert len(devices) == 0
 
 
 @pytest.mark.asyncio
-@patch("greeclimate.network.search_devices")
-async def test_discover_deduplicate_multiple_discoveries(mock_search_devices):
-    mock_search_devices.return_value = [
+async def test_discover_deduplicate_multiple_discoveries(netifaces, search_devices):
+    search_devices.return_value = [
         ("1.1.1.1", "7000", "aabbcc001122", "MockDevice1"),
         ("1.1.1.1", "7000", "aabbcc001122", "MockDevice1"),
         ("1.1.1.2", "7000", "aabbcc001123", "MockDevice2"),
     ]
 
-    devices = await Discovery.search_devices()
+    discovery = discovery = Discovery(allow_loopback=True)
+    devices = await discovery.search_devices()
 
     assert devices is not None
     assert len(devices) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "addr,bcast,family", [(("127.0.0.1", 7000), "127.255.255.255", socket.AF_INET)]
+)
+async def test_discovery_callback(netifaces, addr, bcast, family):
+    netifaces.return_value = {
+        2: [{"addr": addr[0], "netmask": "255.0.0.0", "peer": bcast}]
+    }
+
+    with socket.socket(family, socket.SOCK_DGRAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        sock.bind(("", addr[1]))
+
+        def responder(s):
+            (d, addr) = s.recvfrom(2048)
+            p = json.loads(d)
+            assert p == DISCOVERY_REQUEST
+
+            r = DISCOVERY_RESPONSE
+            r["pack"] = DatagramStream.encrypt_payload(r["pack"])
+            p = json.dumps(r)
+            s.sendto(p.encode(), addr)
+
+        serv = Thread(target=responder, args=(sock,))
+        serv.start()
+
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+
+        async def cb(device_info: DeviceInfo):
+            fut.set_result(True)
+            assert device_info is not None
+
+        discovery = discovery = Discovery(allow_loopback=True)
+        devices = await discovery.search_devices(async_callback=cb)
+        done, _ = await asyncio.wait([fut], timeout=12)
+
+        assert devices is not None
+        assert done is not None
+        assert len(devices) > 0
+        assert len(done) == len(devices)
+
+        serv.join(timeout=DEFAULT_TIMEOUT)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "addr,bcast,family,dresp",
+    [
+        (
+            ("127.0.0.1", 7000),
+            "127.255.255.255",
+            socket.AF_INET,
+            DISCOVERY_RESPONSE_NO_CID,
+        ),
+    ],
+)
+async def test_search_devices(netifaces, addr, bcast, family, dresp):
+    """Create a socket broadcast responder, an async broadcast listener, test
+    discovery responses.
+    """
+    netifaces.return_value = {
+        2: [{"addr": addr[0], "netmask": "255.0.0.0", "peer": bcast}]
+    }
+
+    with socket.socket(family, socket.SOCK_DGRAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        sock.bind(("", addr[1]))
+
+        def responder(s):
+            (d, addr) = s.recvfrom(2048)
+            p = json.loads(d)
+            assert p == DISCOVERY_REQUEST
+
+            r = dresp
+            r["pack"] = DatagramStream.encrypt_payload(r["pack"])
+            p = json.dumps(r)
+            s.sendto(p.encode(), addr)
+
+        serv = Thread(target=responder, args=(sock,))
+        serv.start()
+
+        # Run the listener portion now
+        discovery = discovery = Discovery(allow_loopback=True)
+        response = await discovery.search_devices()
+
+        assert response
+        assert len(response) == 1
+        assert response[0].ip == "127.0.0.1"
+
+        serv.join(timeout=DEFAULT_TIMEOUT)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "addr,bcast,family", [(("127.0.0.1", 7000), "127.255.255.255", socket.AF_INET)]
+)
+async def test_search_devices_bad_data(netifaces, addr, bcast, family):
+    """Create a socket broadcast responder, an async broadcast listener,
+    test discovery responses.
+    """
+    netifaces.return_value = {
+        2: [{"addr": addr[0], "netmask": "255.0.0.0", "peer": bcast}]
+    }
+
+    with socket.socket(family, socket.SOCK_DGRAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        sock.bind(("", addr[1]))
+
+        def responder(s):
+            (d, addr) = s.recvfrom(2048)
+            p = json.loads(d)
+            assert p == DISCOVERY_REQUEST
+
+            s.sendto("garbage data".encode(), addr)
+
+        serv = Thread(target=responder, args=(sock,))
+        serv.start()
+
+        # Run the listener portion now
+        discovery = discovery = Discovery(allow_loopback=True)
+        response = await discovery.search_devices()
+
+        assert response is not None
+        assert len(response) == 0
+
+        serv.join(timeout=DEFAULT_TIMEOUT)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "addr,bcast,family", [(("127.0.0.1", 7000), "127.255.255.255", socket.AF_INET)]
+)
+async def test_search_devices_timeout(netifaces, addr, bcast, family):
+    """Create an async broadcast listener, test discovery responses."""
+    netifaces.return_value = {
+        2: [{"addr": addr[0], "netmask": "255.0.0.0", "peer": bcast}]
+    }
+
+    # Run the listener portion now
+    discovery = discovery = Discovery(allow_loopback=True)
+    response = await discovery.search_devices()
+
+    assert response is not None
+    assert len(response) == 0


### PR DESCRIPTION
Big clean up of the discovery system to make it a bit more robust and inline with the Gree+ process.

1. Discovery code moved into class, so that stream and socket can be reused to send multiple broadcast messages making life better for slow devices.
2. Discovery allows async callback function which is executed immediately once a device responds, users will have to take care to ensure that they don't process devices multiple times since multiple responses for the same device are now possible.
3. Updating tests and adding a bit more coverage