### PR TITLE
Add device_update event for changing ip address

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -151,6 +151,50 @@ async def test_discovery_events(netifaces, addr, bcast, family):
 
 
 @pytest.mark.asyncio
+async def test_discovery_device_update_events():
+    discovery = Discovery(allow_loopback=True)
+    discovery.packet_received(
+        {
+            "pack": {
+                "mac": "aa11bb22cc33",
+                "cid": 1,
+                "name": "MockDevice",
+                "brand": "",
+                "model": "",
+                "ver": "1.0.0",
+            }
+        },
+        ("1.1.1.1", 7000),
+    )
+
+    await asyncio.gather(*discovery.tasks, return_exceptions=True)
+
+    assert len(discovery.devices) == 1
+    assert discovery.devices[0].mac == "aa11bb22cc33"
+    assert discovery.devices[0].ip == "1.1.1.1"
+
+    discovery.packet_received(
+        {
+            "pack": {
+                "mac": "aa11bb22cc33",
+                "cid": 1,
+                "name": "MockDevice",
+                "brand": "",
+                "model": "",
+                "ver": "1.0.0",
+            }
+        },
+        ("1.1.2.2", 7000),
+    )
+
+    await asyncio.gather(*discovery.tasks, return_exceptions=True)
+
+    assert len(discovery.devices) == 1
+    assert discovery.devices[0].mac == "aa11bb22cc33"
+    assert discovery.devices[0].ip == "1.1.2.2"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "addr,bcast,family", [(("127.0.0.1", 7000), "127.255.255.255", socket.AF_INET)]
 )


### PR DESCRIPTION
When a non-unique device is detected on the network, check the IP address from the last known and call `device_update` event when the IP address has changed.

This can be used by discovery listeners to update device endpoints when their ip addresses change.