### PR TITLE
Devices with NULL name use mac instead

### DIFF
--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -110,7 +110,7 @@ class DeviceInfo:
         self.ip = ip
         self.port = port
         self.mac = mac
-        self.name = name if name else self.name
+        self.name = name if name else mac.replace(":", "")
         self.brand = brand
         self.model = model
         self.version = version


### PR DESCRIPTION
MAC addresses are always defined, as required by the Gree protocol, so if a name is null we'll use the MAC instead.

Resolves: #43 