### PR TITLE
Handle undefined bcast or peer IPs from Wireshark

### DIFF
--- a/greeclimate/discovery.py
+++ b/greeclimate/discovery.py
@@ -189,9 +189,11 @@ class Discovery(BroadcastListenerProtocol, Listener):
                 if addr:
                     ip4addr = IPv4Address(ipaddr)
                     if ip4addr.is_loopback and self._allow_loopback:
-                        bdrAddrs.append(IPInterface(ipaddr, bdr or peer))
+                        if bdr or peer:
+                            bdrAddrs.append(IPInterface(ipaddr, bdr or peer))
                     elif not ip4addr.is_loopback:
-                        bdrAddrs.append(IPInterface(ipaddr, bdr))
+                        if bdr:
+                            bdrAddrs.append(IPInterface(ipaddr, bdr))
 
         return bdrAddrs
 


### PR DESCRIPTION
It's possible the a BCast or Peer address of an interface to be undefined, add checks to prevent scanning these interfaces.

Resolves: #42 