### PR TITLE
fix: twine upload error

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
+          pip install importlib_metadata==7.2.1
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
       - uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Caused by license being removed from twine package