### PR TITLE
feat: Support GCM encryption for Gree devices

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="-5ebd8e7a:1905645fe15:-7ffe" />
+      </MTProjectMetadataState>
+    </option>
+    <option name="titleBarState">
+      <MTProjectTitleBarConfigState>
+        <option name="overrideColor" value="false" />
+      </MTProjectTitleBarConfigState>
+    </option>
+  </component>
+</project>

--- a/.idea/ruff.xml
+++ b/.idea/ruff.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="RuffConfigService">
-    <option name="projectRuffExecutablePath" value="$PROJECT_DIR$/venv/bin/ruff" />
-    <option name="projectRuffLspExecutablePath" value="$PROJECT_DIR$/venv/bin/ruff-lsp" />
+    <option name="projectRuffExecutablePath" value="$PROJECT_DIR$/../core/venv/bin/ruff" />
     <option name="runRuffOnSave" value="true" />
   </component>
 </project>

--- a/.idea/ruff.xml
+++ b/.idea/ruff.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RuffConfigService">
+    <option name="projectRuffExecutablePath" value="$PROJECT_DIR$/venv/bin/ruff" />
+    <option name="projectRuffLspExecutablePath" value="$PROJECT_DIR$/venv/bin/ruff-lsp" />
+    <option name="runRuffOnSave" value="true" />
+  </component>
+</project>

--- a/.idea/ruff.xml
+++ b/.idea/ruff.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="RuffConfigService">
-    <option name="projectRuffExecutablePath" value="$PROJECT_DIR$/../core/venv/bin/ruff" />
+    <option name="projectRuffExecutablePath" value="$PROJECT_DIR$/venv/bin/ruff" />
+    <option name="projectRuffLspExecutablePath" value="$PROJECT_DIR$/venv/bin/ruff-lsp" />
     <option name="runRuffOnSave" value="true" />
   </component>
 </project>

--- a/.idea/runConfigurations/pytest_in__.xml
+++ b/.idea/runConfigurations/pytest_in__.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="pytest in /" type="tests" factoryName="py.test" nameIsGenerated="true">
+    <module name="greeclimate" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="_new_keywords" value="&quot;&quot;" />
+    <option name="_new_parameters" value="&quot;&quot;" />
+    <option name="_new_additionalArguments" value="&quot;&quot;" />
+    <option name="_new_target" value="&quot;&quot;" />
+    <option name="_new_targetType" value="&quot;PATH&quot;" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/emulator.py
+++ b/emulator.py
@@ -6,7 +6,6 @@ import json
 import socket
 import time
 
-import machine
 import network
 import ubinascii
 from ucryptolib import aes

--- a/greeclimate/cipher.py
+++ b/greeclimate/cipher.py
@@ -26,7 +26,7 @@ class CipherBase:
 
 
 class CipherV1(CipherBase):
-    def __init__(self, key: bytes) -> None:
+    def __init__(self, key: bytes = b'a3K8Bx%2r8Y7#xDh') -> None:
         super().__init__(key)
 
     def __create_cipher(self) -> AES:
@@ -58,7 +58,7 @@ class CipherV2(CipherBase):
     GCM_NONCE = b'\x54\x40\x78\x44\x49\x67\x5a\x51\x6c\x5e\x63\x13'
     GCM_AEAD = b'qualcomm-test'
 
-    def __init__(self, key: bytes) -> None:
+    def __init__(self, key: bytes = b'{yxAHAY_Lm6pbC/<') -> None:
         super().__init__(key)
 
     def __create_cipher(self) -> AES:

--- a/greeclimate/cipher.py
+++ b/greeclimate/cipher.py
@@ -5,6 +5,7 @@ from typing import Union, Tuple
 
 from Crypto.Cipher import AES
 
+_logger = logging.getLogger(__name__)
 
 class CipherBase:
     def __init__(self, key: bytes) -> None:
@@ -36,21 +37,21 @@ class CipherV1(CipherBase):
         return s + (16 - len(s) % 16) * chr(16 - len(s) % 16)
 
     def encrypt(self, data) -> Tuple[str, Union[str, None]]:
-        logging.debug("Encrypting data: %s", data)
+        _logger.debug("Encrypting data: %s", data)
         cipher = self.__create_cipher()
         padded = self.__pad(json.dumps(data)).encode()
         encrypted = cipher.encrypt(padded)
         encoded = base64.b64encode(encrypted).decode()
-        logging.info("Encrypted data: %s", encoded)
+        _logger.debug("Encrypted data: %s", encoded)
         return encoded, None
 
     def decrypt(self, data) -> dict:
-        logging.info("Decrypting data: %s", data)
+        _logger.debug("Decrypting data: %s", data)
         cipher = self.__create_cipher()
         decoded = base64.b64decode(data)
         decrypted = cipher.decrypt(decoded).decode()
         t = decrypted.replace(decrypted[decrypted.rindex('}') + 1:], '')
-        logging.debug("Decrypted data: %s", t)
+        _logger.debug("Decrypted data: %s", t)
         return json.loads(t)
 
 
@@ -67,21 +68,21 @@ class CipherV2(CipherBase):
         return cipher
 
     def encrypt(self, data) -> Tuple[str, str]:
-        logging.debug("Encrypting data: %s", data)
+        _logger.debug("Encrypting data: %s", data)
         cipher = self.__create_cipher()
         encrypted, tag = cipher.encrypt_and_digest(json.dumps(data).encode())
         encoded = base64.b64encode(encrypted).decode()
         tag = base64.b64encode(tag).decode()
-        logging.debug("Encrypted data: %s", encoded)
-        logging.debug("Cipher digest: %s", tag)
+        _logger.debug("Encrypted data: %s", encoded)
+        _logger.debug("Cipher digest: %s", tag)
         return encoded, tag
 
     def decrypt(self, data) -> dict:
-        logging.info("Decrypting data: %s", data)
+        _logger.info("Decrypting data: %s", data)
         cipher = self.__create_cipher()
         decoded = base64.b64decode(data)
         decrypted = cipher.decrypt(decoded).decode()
         t = decrypted.replace(decrypted[decrypted.rindex('}') + 1:], '')
-        logging.debug("Decrypted data: %s", t)
+        _logger.debug("Decrypted data: %s", t)
         return json.loads(t)
 

--- a/greeclimate/cipher.py
+++ b/greeclimate/cipher.py
@@ -1,0 +1,87 @@
+import base64
+import json
+import logging
+from typing import Union, Tuple
+
+from Crypto.Cipher import AES
+
+
+class CipherBase:
+    def __init__(self, key: bytes) -> None:
+        self._key: bytes = key
+        
+    @property
+    def key(self) -> str:
+        return self._key.decode()
+    
+    @key.setter
+    def key(self, value: str) -> None:
+        self._key = value.encode()
+        
+    def encrypt(self, data) -> Tuple[str, Union[str, None]]:
+        raise NotImplementedError
+
+    def decrypt(self, data) -> dict:
+        raise NotImplementedError
+
+
+class CipherV1(CipherBase):
+    def __init__(self, key: bytes) -> None:
+        super().__init__(key)
+
+    def __create_cipher(self) -> AES:
+        return AES.new(self._key, AES.MODE_ECB)
+
+    def __pad(self, s) -> str:
+        return s + (16 - len(s) % 16) * chr(16 - len(s) % 16)
+
+    def encrypt(self, data) -> Tuple[str, Union[str, None]]:
+        logging.debug("Encrypting data: %s", data)
+        cipher = self.__create_cipher()
+        padded = self.__pad(json.dumps(data)).encode()
+        encrypted = cipher.encrypt(padded)
+        encoded = base64.b64encode(encrypted).decode()
+        logging.info("Encrypted data: %s", encoded)
+        return encoded, None
+
+    def decrypt(self, data) -> dict:
+        logging.info("Decrypting data: %s", data)
+        cipher = self.__create_cipher()
+        decoded = base64.b64decode(data)
+        decrypted = cipher.decrypt(decoded).decode()
+        t = decrypted.replace(decrypted[decrypted.rindex('}') + 1:], '')
+        logging.debug("Decrypted data: %s", t)
+        return json.loads(t)
+
+
+class CipherV2(CipherBase):
+    GCM_NONCE = b'\x54\x40\x78\x44\x49\x67\x5a\x51\x6c\x5e\x63\x13'
+    GCM_AEAD = b'qualcomm-test'
+
+    def __init__(self, key: bytes) -> None:
+        super().__init__(key)
+
+    def __create_cipher(self) -> AES:
+        cipher = AES.new(self._key, AES.MODE_GCM, nonce=self.GCM_NONCE)
+        cipher.update(self.GCM_AEAD)
+        return cipher
+
+    def encrypt(self, data) -> Tuple[str, str]:
+        logging.debug("Encrypting data: %s", data)
+        cipher = self.__create_cipher()
+        encrypted, tag = cipher.encrypt_and_digest(json.dumps(data).encode())
+        encoded = base64.b64encode(encrypted).decode()
+        tag = base64.b64encode(tag).decode()
+        logging.debug("Encrypted data: %s", encoded)
+        logging.debug("Cipher digest: %s", tag)
+        return encoded, tag
+
+    def decrypt(self, data) -> dict:
+        logging.info("Decrypting data: %s", data)
+        cipher = self.__create_cipher()
+        decoded = base64.b64decode(data)
+        decrypted = cipher.decrypt(decoded).decode()
+        t = decrypted.replace(decrypted[decrypted.rindex('}') + 1:], '')
+        logging.debug("Decrypted data: %s", t)
+        return json.loads(t)
+

--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -6,7 +6,7 @@ from asyncio import AbstractEventLoop
 from enum import IntEnum, unique
 from typing import Union
 
-from greeclimate.cipher import CipherV1, CipherV2, CipherBase
+from greeclimate.cipher import CipherV1, CipherV2
 from greeclimate.deviceinfo import DeviceInfo
 from greeclimate.exceptions import DeviceNotBoundError, DeviceTimeoutError
 from greeclimate.network import DeviceProtocol2
@@ -247,8 +247,6 @@ class Device(DeviceProtocol2, Taskable):
     def handle_device_bound(self, key: str) -> None:
         """Handle the device bound message from the device"""
         cipher_type = type(self.device_cipher)
-        if not issubclass(cipher_type, CipherBase):
-            raise ValueError(f"Invalid cipher type {cipher_type}")
         self.device_cipher = cipher_type(key.encode())
 
     async def request_version(self) -> None:

--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -161,13 +161,6 @@ class Device(DeviceProtocol2, Taskable):
         water_full: A bool to indicate the water tank is full
     """
 
-    """ Device properties """
-    hid = None
-    version = None
-    check_version = True
-    _properties = {}
-    _dirty = []
-
     def __init__(self, device_info: DeviceInfo, timeout: int = 120, loop: AbstractEventLoop = None):
         """Initialize the device object
 
@@ -180,6 +173,14 @@ class Device(DeviceProtocol2, Taskable):
         Taskable.__init__(self, loop)
         self._logger = logging.getLogger(__name__)
         self.device_info: DeviceInfo = device_info
+        
+        """ Device properties """
+        self.hid = None
+        self.version = None
+        self.check_version = True
+        self._properties = {}
+        self._dirty = []
+
 
     async def bind(self, key: str = None, cipher_type: Union[type[Union[CipherV1, CipherV2]], None] = None):
         """Run the binding procedure.

--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -44,12 +44,6 @@ class Props(enum.Enum):
     UNKNOWN_HEATCOOLTYPE = "HeatCoolType"
 
 
-GENERIC_CIPHERS_KEYS = {
-    CipherV1: b'a3K8Bx%2r8Y7#xDh',
-    CipherV2: b'{yxAHAY_Lm6pbC/<'
-}
-
-
 @unique
 class TemperatureUnits(IntEnum):
     C = 0
@@ -240,8 +234,7 @@ class Device(DeviceProtocol2, Taskable):
 
     async def __bind_internal(self, cipher_type: type[Union[CipherV1, CipherV2]]):
         """Internal binding procedure, do not call directly"""
-        default_key = GENERIC_CIPHERS_KEYS.get(cipher_type)
-        await self.send(self.create_bind_message(self.device_info), cipher=cipher_type(default_key))
+        await self.send(self.create_bind_message(self.device_info), cipher=cipher_type())
         task = asyncio.create_task(self.ready.wait())
         await asyncio.wait_for(task, timeout=self._timeout)
 

--- a/greeclimate/discovery.py
+++ b/greeclimate/discovery.py
@@ -6,6 +6,7 @@ from asyncio import Task
 from asyncio.events import AbstractEventLoop
 from ipaddress import IPv4Address
 
+from greeclimate.cipher import CipherV1
 from greeclimate.device import DeviceInfo
 from greeclimate.network import BroadcastListenerProtocol, IPAddr
 from greeclimate.taskable import Taskable
@@ -45,6 +46,7 @@ class Discovery(BroadcastListenerProtocol, Listener, Taskable):
         """
         BroadcastListenerProtocol.__init__(self, timeout)
         Taskable.__init__(self, loop)
+        self.device_cipher = CipherV1()
         self._allow_loopback: bool = allow_loopback
         self._device_infos: list[DeviceInfo] = []
         self._listeners: list[Listener] = []

--- a/greeclimate/network.py
+++ b/greeclimate/network.py
@@ -38,9 +38,6 @@ class IPInterface:
 class DeviceProtocolBase2(asyncio.DatagramProtocol):
     """Event driven device protocol class."""
 
-    _transport: Union[asyncio.transports.DatagramTransport, None] = None
-    _cipher: Union[CipherBase, None] = None
-
     def __init__(self, timeout: int = 10, drained: asyncio.Event = None) -> None:
         """Initialize the device protocol object.
 
@@ -51,6 +48,10 @@ class DeviceProtocolBase2(asyncio.DatagramProtocol):
         self._timeout: int = timeout
         self._drained: asyncio.Event = drained or asyncio.Event()
         self._drained.set()
+
+        self._transport: Union[asyncio.transports.DatagramTransport, None] = None
+        self._cipher: Union[CipherBase, None] = None
+
 
     # This event need to be implemented to handle incoming requests
     def packet_received(self, obj, addr: IPAddr) -> None:

--- a/greeclimate/network.py
+++ b/greeclimate/network.py
@@ -136,7 +136,9 @@ class DeviceProtocolBase2(asyncio.DatagramProtocol):
 
         if obj.get("pack"):
             cipher = CipherV1(GENERIC_CIPHERS_KEYS[0]) if obj.get("i") == 1 else self._cipher
-            obj["pack"], _ = cipher.encrypt(obj["pack"])
+            obj["pack"], tag = cipher.encrypt(obj["pack"])
+            if tag:
+                obj["tag"] = tag
 
         data_bytes = json.dumps(obj).encode()
         self._transport.sendto(data_bytes, addr)

--- a/greeclimate/network.py
+++ b/greeclimate/network.py
@@ -229,12 +229,13 @@ class DeviceProtocol2(DeviceProtocolBase2):
             Response.DATA.value: lambda *args: self.__handle_state_update(*args),
             Response.RESULT.value: lambda *args: self.__handle_state_update(*args),
         }
-        resp = obj.get("pack", {}).get("t")
-        handler = handlers.get(resp, self.handle_unknown_packet)
-        param = []
         try:
+            resp = obj.get("pack", {}).get("t")
+            handler = handlers.get(resp, self.handle_unknown_packet)
             param = params.get(resp, lambda o, a: (o, a))(obj, addr)
             handler(*param)
+        except AttributeError as e:
+            _LOGGER.exception("Error while handling packet", exc_info=e)
         except KeyError as e:
             _LOGGER.exception("Error while handling packet", exc_info=e)
         else:

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,7 +4,6 @@ from typing import Tuple, Union
 from unittest.mock import Mock
 
 from greeclimate.cipher import CipherV1, CipherBase
-from greeclimate.device import GENERIC_CIPHERS_KEYS
 
 DEFAULT_TIMEOUT = 1
 DISCOVERY_REQUEST = {"t": "scan"}
@@ -96,7 +95,7 @@ def get_mock_device_info():
 def encrypt_payload(data):
     """Encrypt the payload of responses quickly."""
     d = data.copy()
-    cipher = CipherV1(GENERIC_CIPHERS_KEYS[CipherV1])
+    cipher = CipherV1()
     d["pack"], _ = cipher.encrypt(d["pack"])
     return d
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,9 +1,10 @@
-import asyncio
 import socket
 from socket import SOCK_DGRAM
-from unittest.mock import Mock, create_autospec, patch
+from typing import Tuple, Union
+from unittest.mock import Mock
 
-from greeclimate.network import DeviceProtocolBase2
+from greeclimate.cipher import CipherV1, CipherBase
+from greeclimate.network import GENERIC_CIPHERS_KEYS
 
 DEFAULT_TIMEOUT = 1
 DISCOVERY_REQUEST = {"t": "scan"}
@@ -95,8 +96,22 @@ def get_mock_device_info():
 def encrypt_payload(data):
     """Encrypt the payload of responses quickly."""
     d = data.copy()
-    d["pack"] = DeviceProtocolBase2.encrypt_payload(d["pack"])
+    cipher = CipherV1(GENERIC_CIPHERS_KEYS[0])
+    d["pack"], _ = cipher.encrypt(d["pack"])
     return d
+
+
+class FakeCipher(CipherBase):
+    """Fake cipher object for testing."""
+
+    def __init__(self, key: bytes) -> None:
+        super().__init__(key)
+
+    def encrypt(self, data) -> Tuple[str, Union[str, None]]:
+        return data, None
+
+    def decrypt(self, data) -> dict:
+        return data
 
 
 class Responder:

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,7 +4,7 @@ from typing import Tuple, Union
 from unittest.mock import Mock
 
 from greeclimate.cipher import CipherV1, CipherBase
-from greeclimate.network import GENERIC_CIPHERS_KEYS
+from greeclimate.device import GENERIC_CIPHERS_KEYS
 
 DEFAULT_TIMEOUT = 1
 DISCOVERY_REQUEST = {"t": "scan"}
@@ -96,7 +96,7 @@ def get_mock_device_info():
 def encrypt_payload(data):
     """Encrypt the payload of responses quickly."""
     d = data.copy()
-    cipher = CipherV1(GENERIC_CIPHERS_KEYS[0])
+    cipher = CipherV1(GENERIC_CIPHERS_KEYS[CipherV1])
     d["pack"], _ = cipher.encrypt(d["pack"])
     return d
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+from greeclimate.device import Device
 from tests.common import FakeCipher
 
 MOCK_INTERFACES = ["lo"]
@@ -20,11 +21,17 @@ def netifaces_fixture():
         yield ifaddr_mock
 
 
-
-@pytest.fixture(name="cipher")
+@pytest.fixture(name="cipher", autouse=False, scope="function")
 def cipher_fixture():
     """Patch the cipher object."""
     with patch("greeclimate.device.CipherV1") as mock1, patch("greeclimate.device.CipherV2") as mock2:
         mock1.return_value = FakeCipher(b"1234567890123456")
         mock2.return_value = FakeCipher(b"1234567890123456")
-        yield
+        yield mock1, mock2
+
+
+@pytest.fixture(name="send", autouse=False, scope="function")
+def network_fixture():
+    """Patch the device object."""
+    with patch.object(Device, "send") as mock:
+        yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.common import FakeCipher
+
 MOCK_INTERFACES = ["lo"]
 MOCK_LO_IFACE = {
     2: [{"addr": "10.0.0.1", "netmask": "255.0.0.0", "peer": "10.255.255.255"}]
@@ -13,6 +15,16 @@ MOCK_LO_IFACE = {
 def netifaces_fixture():
     """Patch netifaces interface discover."""
     with patch("netifaces.interfaces", return_value=MOCK_INTERFACES), patch(
-        "netifaces.ifaddresses", return_value=MOCK_LO_IFACE
+            "netifaces.ifaddresses", return_value=MOCK_LO_IFACE
     ) as ifaddr_mock:
         yield ifaddr_mock
+
+
+
+@pytest.fixture(name="cipher")
+def cipher_fixture():
+    """Patch the cipher object."""
+    with patch("greeclimate.network.CipherV1") as mock1, patch("greeclimate.cipher.CipherV2") as mock2:
+        mock1.return_value = FakeCipher(b"1234567890123456")
+        mock2.return_value = FakeCipher(b"1234567890123456")
+        yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def netifaces_fixture():
 @pytest.fixture(name="cipher")
 def cipher_fixture():
     """Patch the cipher object."""
-    with patch("greeclimate.network.CipherV1") as mock1, patch("greeclimate.cipher.CipherV2") as mock2:
+    with patch("greeclimate.device.CipherV1") as mock1, patch("greeclimate.device.CipherV2") as mock2:
         mock1.return_value = FakeCipher(b"1234567890123456")
         mock2.return_value = FakeCipher(b"1234567890123456")
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def netifaces_fixture():
         yield ifaddr_mock
 
 
-@pytest.fixture(name="cipher", autouse=False, scope="function")
+@pytest.fixture(name="cipher")
 def cipher_fixture():
     """Patch the cipher object."""
     with patch("greeclimate.device.CipherV1") as mock1, patch("greeclimate.device.CipherV2") as mock2:
@@ -30,7 +30,7 @@ def cipher_fixture():
         yield mock1, mock2
 
 
-@pytest.fixture(name="send", autouse=False, scope="function")
+@pytest.fixture(name="send")
 def network_fixture():
     """Patch the device object."""
     with patch.object(Device, "send") as mock:

--- a/tests/test_cipher.py
+++ b/tests/test_cipher.py
@@ -1,6 +1,8 @@
 import base64
+
 import pytest
-from greeclimate.cipher import CipherV1, CipherV2
+
+from greeclimate.cipher import CipherV1, CipherV2, CipherBase
 
 
 @pytest.fixture
@@ -46,3 +48,13 @@ def test_encryption_then_decryption_yields_original_with_tag(cipher_v2, plain_te
     decrypted = cipher_v2.decrypt(encrypted)
     assert decrypted == plain_text
 
+
+def test_cipher_base_not_implemented():
+    fake_key = b'fake'
+    
+    with pytest.raises(NotImplementedError):
+        CipherBase(fake_key).encrypt(None)
+        
+    with pytest.raises(NotImplementedError):
+        CipherBase(fake_key).decrypt(None)
+        

--- a/tests/test_cipher.py
+++ b/tests/test_cipher.py
@@ -1,0 +1,48 @@
+import base64
+import pytest
+from greeclimate.cipher import CipherV1, CipherV2
+
+
+@pytest.fixture
+def cipher_v1_key():
+    return b'ThisIsASecretKey'
+
+
+@pytest.fixture
+def cipher_v1(cipher_v1_key):
+    return CipherV1(cipher_v1_key)
+
+
+@pytest.fixture
+def cipher_v2_key():
+    return b'ThisIsASecretKey'
+
+
+@pytest.fixture
+def cipher_v2(cipher_v2_key):
+    return CipherV2(cipher_v2_key)
+
+
+@pytest.fixture
+def plain_text():
+    return {"message": "Hello, World!"}
+
+
+def test_encryption_then_decryption_yields_original(cipher_v1, plain_text):
+    encrypted, _ = cipher_v1.encrypt(plain_text)
+    decrypted = cipher_v1.decrypt(encrypted)
+    assert decrypted == plain_text
+
+
+def test_decryption_with_modified_data_raises_error(cipher_v1, plain_text):
+    _, _ = cipher_v1.encrypt(plain_text)
+    modified_data = base64.b64encode(b"modified data   ").decode()
+    with pytest.raises(UnicodeDecodeError):
+        cipher_v1.decrypt(modified_data)
+
+
+def test_encryption_then_decryption_yields_original_with_tag(cipher_v2, plain_text):
+    encrypted, tag = cipher_v2.encrypt(plain_text)
+    decrypted = cipher_v2.decrypt(encrypted)
+    assert decrypted == plain_text
+

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -158,7 +158,7 @@ def get_mock_state_0c_v3_temp():
 
 async def generate_device_mock_async():
     d = Device(DeviceInfo("1.1.1.1", 7000, "f4911e7aca59", "1e7aca59"))
-    await d.bind(key="St8Vw1Yz4Bc7Ef0H", cipher_type=CipherV1)
+    await d.bind(key="St8Vw1Yz4Bc7Ef0H", cipher=CipherV1())
     return d
 
 
@@ -195,7 +195,7 @@ async def test_get_device_info(cipher, send):
     assert device.device_info == info
 
     fake_key = "abcdefgh12345678"
-    await device.bind(key=fake_key, cipher_type=CipherV1)
+    await device.bind(key=fake_key, cipher=CipherV1())
 
     assert device.device_cipher is not None
     assert device.device_cipher.key == fake_key
@@ -665,22 +665,22 @@ async def test_device_equality(send):
 
     info1 = DeviceInfo(*get_mock_info())
     device1 = Device(info1)
-    await device1.bind(key="fake_key", cipher_type=CipherV1)
+    await device1.bind(key="fake_key", cipher=CipherV1())
 
     info2 = DeviceInfo(*get_mock_info())
     device2 = Device(info2)
-    await device2.bind(key="fake_key", cipher_type=CipherV1)
+    await device2.bind(key="fake_key", cipher=CipherV1())
 
     assert device1 == device2
 
     # Change the key of the second device
-    await device2.bind(key="another_fake_key", cipher_type=CipherV1)
+    await device2.bind(key="another_fake_key", cipher=CipherV1())
     assert device1 != device2
 
     # Change the info of the second device
     info2 = DeviceInfo(*get_mock_info())
     device2 = Device(info2)
     device2.power = True
-    await device2.bind(key="fake_key", cipher_type=CipherV1)
+    await device2.bind(key="fake_key", cipher=CipherV1())
     assert device1 != device2
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -281,6 +281,26 @@ async def test_device_late_bind(cipher, send):
 
 
 @pytest.mark.asyncio
+async def test_device_bind_no_cipher(cipher, send):
+    """Check that the device handles late binding sequences."""
+    info = DeviceInfo(*get_mock_info())
+    device = Device(info, timeout=1)
+    fake_key = "abcdefgh12345678"
+    
+    with pytest.raises(ValueError):
+        await device.bind(fake_key)
+
+
+@pytest.mark.asyncio
+async def test_device_bind_no_device_info(cipher, send):
+    """Check that the device handles late binding sequences."""
+    device = Device(None, timeout=1)
+    
+    with pytest.raises(DeviceNotBoundError):
+        await device.bind()
+
+
+@pytest.mark.asyncio
 async def test_update_properties(cipher, send):
     """Check that properties can be updates."""
     device = await generate_device_mock_async()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,24 +1,18 @@
 import asyncio
 import json
 import socket
-from asyncio.tasks import wait_for
 from threading import Thread
-from unittest.mock import MagicMock, PropertyMock, create_autospec, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
-from greeclimate.device import DeviceInfo
 from greeclimate.discovery import Discovery, Listener
-from greeclimate.network import DeviceProtocolBase2
-
 from .common import (
     DEFAULT_TIMEOUT,
     DISCOVERY_REQUEST,
     DISCOVERY_RESPONSE,
-    DISCOVERY_RESPONSE_NO_CID,
     Responder,
-    encrypt_payload,
-    get_mock_device_info,
+    get_mock_device_info, encrypt_payload,
 )
 
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -15,7 +15,7 @@ async def test_issue_69_TemSen_40_should_not_set_firmware_v4():
     for p in Props:
         assert device.get_property(p) is None
 
-    def fake_send(*args):
+    def fake_send(*args, **kwargs):
         device.handle_state_update(**mock_v3_state)
 
     with patch.object(Device, "send", wraps=fake_send()):
@@ -35,7 +35,7 @@ async def test_issue_87_quiet_should_set_2():
     assert device.get_property(Props.QUIET) is None
     device.quiet = True
 
-    def fake_send(*args):
+    def fake_send(*args, **kwargs):
         device.handle_state_update(**mock_v3_state)
 
     with patch.object(Device, "send", wraps=fake_send()) as mock:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -497,3 +497,52 @@ async def test_add_and_remove_handler(event_name, data):
     # Check that the callback was not called this time
     callback.assert_not_called()
 
+
+def test_packet_received_not_implemented():
+    # Arrange
+    protocol = DeviceProtocolBase2()
+
+    # Act
+    with pytest.raises(NotImplementedError):
+        protocol.packet_received({}, ("0.0.0.0", 0))
+        
+        
+def test_packet_received_invalid_data():
+    # Arrange
+    protocol = DeviceProtocol2()
+
+    # Act
+    protocol.packet_received(None, ("0.0.0.0", 0))
+    protocol.packet_received({"pack"}, ("0.0.0.0", 0))
+    
+    with patch.object(protocol, "handle_unknown_packet") as mock:
+        protocol.packet_received({"pack": {"t": "unknown"}}, ("0.0.0.0", 0))
+        mock.assert_called_once()
+
+
+def test_cipher_is_not_set():
+    # Arrange
+    protocol = DeviceProtocolBase2()
+
+    # Act
+    key = None
+    with pytest.raises(ValueError):
+        key = protocol.device_key
+        
+    assert key is None
+    
+    with pytest.raises(ValueError):
+        protocol.device_key = "fake-key"
+    
+    
+def test_add_invalid_handler():
+    # Arrange
+    protocol = DeviceProtocol2()
+    callback = MagicMock()
+    
+    # Act
+    with pytest.raises(ValueError):
+        protocol.add_handler(Response("invalid"), callback)
+    
+    with pytest.raises(ValueError):
+        protocol.add_handler(Response("invalid"), callback)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -513,11 +513,24 @@ def test_packet_received_invalid_data():
 
     # Act
     protocol.packet_received(None, ("0.0.0.0", 0))
+    protocol.packet_received({}, ("0.0.0.0", 0))
     protocol.packet_received({"pack"}, ("0.0.0.0", 0))
     
     with patch.object(protocol, "handle_unknown_packet") as mock:
         protocol.packet_received({"pack": {"t": "unknown"}}, ("0.0.0.0", 0))
         mock.assert_called_once()
+
+
+def test_set_get_cipher():
+    # Arrange
+    protocol = DeviceProtocolBase2()
+    cipher = FakeCipher(b"1234567890123456")
+
+    # Act
+    protocol.device_cipher = cipher
+
+    # Assert
+    assert protocol.device_cipher == cipher
 
 
 def test_cipher_is_not_set():

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -559,3 +559,16 @@ def test_add_invalid_handler():
     
     with pytest.raises(ValueError):
         protocol.add_handler(Response("invalid"), callback)
+
+
+def test_device_key_get_set():
+    # Arrange
+    protocol = DeviceProtocolBase2
+    key = "fake-key"
+    
+    # Act
+    protocol.device_key = key
+    
+    # Assert
+    assert protocol.device_key == key
+    


### PR DESCRIPTION
Adds support for GCM encryption used on some (newer) Gree devices. Since it's not clear yet how to identify these devices by their announce information, the older AES ECB key will be tried first, then attempt the AES GCM key.

Changes:
- [x] Finish Cipher AES-GCM support
- [x] Reduce 120 timeout on binding wait only
- [x] Add tests
- [x] Verify in Home Assistant