### PR TITLE
Make Device.update_state and Device.push_state_update wait for a reply from the AC

### DIFF
--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -342,8 +342,12 @@ class Device(DeviceProtocol2, Taskable):
         self._dirty.clear()
 
         try:
+            self._update_state_complete.clear()
             await self.send(self.create_command_message(self.device_info, **props))
 
+            if wait_for > 0:
+                task = asyncio.create_task(self._update_state_complete.wait())
+                await asyncio.wait_for(task, timeout=wait_for)
         except asyncio.TimeoutError:
             raise DeviceTimeoutError
 

--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -171,6 +171,7 @@ class Device(DeviceProtocol2, Taskable):
         self.device_info: DeviceInfo = device_info
         
         self._bind_timeout = bind_timeout
+        self._update_state_complete = asyncio.Event()
         
         """ Device properties """
         self.hid = None
@@ -262,11 +263,14 @@ class Device(DeviceProtocol2, Taskable):
         except asyncio.TimeoutError:
             raise DeviceTimeoutError
 
-    async def update_state(self, wait_for: float = 30):
+    async def update_state(self, wait_for: float = 30) -> None:
         """Update the internal state of the device structure of the physical device, 0 for no wait
 
         Args:
             wait_for (object): How long to wait for an update from the device
+
+        Raises:
+            DeviceTimeoutError: The device didn't respond within the timeout
         """
         if not self.device_cipher:
             await self.bind()
@@ -278,8 +282,12 @@ class Device(DeviceProtocol2, Taskable):
             props.append("hid")
 
         try:
+            self._update_state_complete.clear()
             await self.send(self.create_status_message(self.device_info, *props))
 
+            if wait_for > 0:
+                task = asyncio.create_task(self._update_state_complete.wait())
+                await asyncio.wait_for(task, timeout=wait_for)
         except asyncio.TimeoutError:
             raise DeviceTimeoutError
 
@@ -303,6 +311,8 @@ class Device(DeviceProtocol2, Taskable):
                 self.version = "4.0"
                 self._logger.info(f"Device version changed to {self.version}, hid {self.hid}")
             self._logger.debug(f"Using device temperature {self.current_temperature}")
+
+        self._update_state_complete.set()
 
     async def push_state_update(self, wait_for: float = 30):
         """Push any pending state updates to the unit

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -232,7 +232,7 @@ async def test_device_bind(cipher, send):
 async def test_device_bind_timeout(cipher, send):
     """Check that the device handles timeout errors when binding."""
     info = DeviceInfo(*get_mock_info())
-    device = Device(info, timeout=1)
+    device = Device(info, bind_timeout=1)
 
     with pytest.raises(DeviceTimeoutError):
         await device.bind()
@@ -271,7 +271,7 @@ async def test_device_late_bind_from_update(cipher, send):
         device.ready.set()
     send.side_effect = fake_send
 
-    await device.update_state()
+    await device.update_state(0)
     assert send.call_count == 2
     assert device.device_cipher.key == fake_key
 
@@ -344,12 +344,21 @@ async def test_update_properties(cipher, send):
 
 @pytest.mark.asyncio
 async def test_update_properties_timeout(cipher, send):
-    """Check that timeouts are handled when properties are updates."""
+    """Check that timeouts are handled when properties are updated."""
     device = await generate_device_mock_async()
 
     send.side_effect = asyncio.TimeoutError
     with pytest.raises(DeviceTimeoutError):
         await device.update_state()
+
+
+@pytest.mark.asyncio
+async def test_update_properties_timeout_reply(cipher, send):
+    """Check that reply timeouts are handled when properties are updated."""
+    device = await generate_device_mock_async()
+
+    with pytest.raises(DeviceTimeoutError):
+        await device.update_state(wait_for=1)
 
 
 @pytest.mark.asyncio
@@ -694,7 +703,7 @@ async def test_mismatch_temrec_farenheit(temperature, cipher, send):
 
     def fake_send(*args, **kwargs):
         device.handle_state_update(**state)
-    send.side_effect = None
+    send.side_effect = fake_send
 
     await device.update_state()
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -18,7 +18,7 @@ async def test_issue_69_TemSen_40_should_not_set_firmware_v4():
     def fake_send(*args, **kwargs):
         device.handle_state_update(**mock_v3_state)
 
-    with patch.object(Device, "send", wraps=fake_send()):
+    with patch.object(Device, "send", wraps=fake_send):
         await device.update_state()
         assert device.version is None
 
@@ -38,7 +38,7 @@ async def test_issue_87_quiet_should_set_2():
     def fake_send(*args, **kwargs):
         device.handle_state_update(**mock_v3_state)
 
-    with patch.object(Device, "send", wraps=fake_send()) as mock:
+    with patch.object(Device, "send", wraps=fake_send) as mock:
         await device.push_state_update()
         mock.assert_called_once()
 


### PR DESCRIPTION
The `Device.update_state` and `Device.push_state_update` methods previously sent requests to the remote device without awaiting a response, leaving the caller unable to verify whether the operation was successfully received and confirmed.

This PR modifies that behavior. Both methods now wait for a response from the device before returning.

Additionally, although both methods already accepted a `wait_for` parameter, but it was ignored.  This parameter is now used as the timeout for receiving the response.  If no response is received within the specified time, an exception is raised.