### PR TITLE
Fix push_state_update to only clear dirty properties on success

### DIFF
--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -329,13 +329,14 @@ class Device(DeviceProtocol2, Taskable):
                     Props.TEMP_UNIT.value
                 )
 
-        self._dirty.clear()
-
         try:
             await self.send(self.create_command_message(self.device_info, **props))
 
         except asyncio.TimeoutError:
             raise DeviceTimeoutError
+        else:
+            self._dirty.clear()
+
 
     def __eq__(self, other):
         """Compare two devices for equality based on their properties state and device info."""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -429,6 +429,8 @@ async def test_set_properties_timeout(cipher, send):
     with pytest.raises(DeviceTimeoutError):
         await device.push_state_update()
 
+    assert len(device._dirty)
+
 
 @pytest.mark.asyncio
 async def test_uninitialized_properties(cipher, send):
@@ -733,4 +735,3 @@ def test_device_key_set_get():
     device.device_cipher = CipherV1()
     device.device_key = "fake_key"
     assert device.device_key == "fake_key"
-    


### PR DESCRIPTION
The `Device.push_state_update` method only pushes values of properties, which were actually changed.  This is tracked using the `_dirty` instance variable.

So far, the `_dirty` flag was cleared unconditionally, before sending messages to the AC.  This commit makes sure it is done only after successfully sending the message.  In case of errors, the `_dirty` state will be preserved, so a subsequent call to `push_state_update` will re-attempt sending the same properties.