### PR TITLE
fix: support for devices with alternate response format

### DIFF
--- a/greeclimate/network.py
+++ b/greeclimate/network.py
@@ -222,7 +222,7 @@ class DeviceProtocol2(DeviceProtocolBase2):
         params = {
             Response.BIND_OK.value: lambda o, a: [o["pack"]["key"]],
             Response.DATA.value: lambda o, a: [dict(zip(o["pack"]["cols"], o["pack"]["dat"]))],
-            Response.RESULT.value: lambda o, a: [dict(zip(o["pack"]["opt"], o["pack"]["val"]))],
+            Response.RESULT.value: lambda o, a: [dict(zip(o["pack"]["opt"], o["pack"].get("val", []) or o["pack"].get("p", [])))],
         }
         handlers = {
             Response.BIND_OK.value: lambda *args: self.__handle_device_bound(*args),

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -375,7 +375,8 @@ def test_handle_state_update():
     assert protocol.state == {'key': 'value'}
 
 
-def test_handle_result_update():
+@pytest.mark.parametrize('values_key', ['val', 'p'])
+def test_handle_result_update(values_key):
 
     # Arrange
     protocol = DeviceProtocol2Test()
@@ -386,7 +387,7 @@ def test_handle_result_update():
         'pack': {
             't': 'res',
             'opt': list(state.keys()),
-            'val': list(state.values())
+            values_key: list(state.values())
         }
     }, ("0.0.0.0", 0))
 


### PR DESCRIPTION
Some devices, return `pack.p` instead of `pack.val` in the `RESULT` response.

Rebased from #110