### PR TITLE
feat: add buzzer property to control device beep on commands

### DIFF
--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -179,6 +179,7 @@ class Device(DeviceProtocol2, Taskable):
         self.check_version = True
         self._properties = {}
         self._dirty = []
+        self._buzzer = True
 
         self._valid_state: asyncio.Event = asyncio.Event()
         self._valid_state.clear()
@@ -330,6 +331,10 @@ class Device(DeviceProtocol2, Taskable):
                 props[Props.TEMP_UNIT.value] = self._properties.get(
                     Props.TEMP_UNIT.value
                 )
+
+        if not self._buzzer:
+            self._logger.debug("Disabling buzzer for command")
+            props["Buzzer_ON_OFF"] = 1
 
         try:
             await self.send(self.create_command_message(self.device_info, **props))
@@ -591,3 +596,11 @@ class Device(DeviceProtocol2, Taskable):
     def water_full(self) -> Optional[bool]:
         prop = self.get_property(Props.WATER_FULL)
         return bool(prop) if prop is not None else None
+
+    @property
+    def buzzer(self) -> bool:
+        return self._buzzer
+
+    @buzzer.setter
+    def buzzer(self, value: bool):
+        self._buzzer = bool(value)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -743,7 +743,53 @@ def test_device_key_set_get():
     device.device_key = "fake_key"
     assert device.device_key == "fake_key"
 
-    
+
+@pytest.mark.asyncio
+async def test_buzzer_default(cipher, send):
+    """Check that buzzer is enabled by default."""
+    device = await generate_device_mock_async()
+    assert device.buzzer is True
+
+
+@pytest.mark.asyncio
+async def test_buzzer_disabled(cipher, send):
+    """Check that disabling buzzer injects Buzzer_ON_OFF into commands."""
+    device = await generate_device_mock_async()
+
+    device.power = True
+    device.buzzer = False
+    await device.push_state_update()
+    assert send.call_count == 1
+    assert "Buzzer_ON_OFF" in send.call_args_list[0].args[0]["pack"]["opt"]
+    assert not device.buzzer
+
+    send.reset_mock()
+
+    device.power = False
+    device.buzzer = True
+    await device.push_state_update()
+    assert send.call_count == 1
+    assert "Buzzer_ON_OFF" not in send.call_args_list[0].args[0]["pack"]["opt"]
+    assert device.buzzer
+
+
+@pytest.mark.asyncio
+async def test_buzzer_disabled_every_command(cipher, send):
+    """Check that Buzzer_ON_OFF is sent with every command when disabled."""
+    device = await generate_device_mock_async()
+    device.buzzer = False
+
+    device.power = True
+    await device.push_state_update()
+    assert "Buzzer_ON_OFF" in send.call_args_list[0].args[0]["pack"]["opt"]
+
+    send.reset_mock()
+
+    device.mode = 1
+    await device.push_state_update()
+    assert "Buzzer_ON_OFF" in send.call_args_list[0].args[0]["pack"]["opt"]
+
+
 @pytest.mark.asyncio
 async def has_valid_state_with_valid_properties(cipher, send):
     """Check that the device has a valid state with valid properties."""


### PR DESCRIPTION
## Proposed solution

  After analyzing both positions, **@namezys is technically correct**: `Buzzer_ON_OFF` cannot work through `Props`/`_properties` because:

  1. The `_dirty` list is cleared after each `push_state_update()`, so the flag would only be sent once instead of with every command
  2. The device returns inconsistent values when reading this property, making `update_state()` unreliable for it
  3. Requesting an unsupported property could cause older firmware to drop the entire request

  The implementation stores `buzzer` as a **client-side preference** (`_buzzer` attribute) that gets injected into every `push_state_update()` call when disabled. This correctly models the transient nature of the flag while providing a clean API surface.

  ### Key differences from #119

  | Aspect | PR #119 | This PR |
  |----------------|------------------------------------|--------------------------------------------------------------------|
  | Property name | `beep`                                                | `buzzer` (matches Gree protocol `Buzzer_ON_OFF` and HA conventions) |
  | Default value    | `False` (breaking change!)              | `True` (preserves factory behavior)                                                       |
  | Log message    | typo "nuzzer"                                    | fixed                                                                                                           |

  ### Home Assistant compatibility

  This is designed to be consumed in the HA Gree integration as a `SwitchEntity` with `EntityCategory.CONFIG`, following the same descriptor pattern already used for light, quiet, xfan, etc.

  ## Test plan

  - [x] Buzzer is `True` by default (factory behavior preserved)
  - [x] When `buzzer=False`, `Buzzer_ON_OFF` is included in every command
  - [x] When `buzzer=True`, `Buzzer_ON_OFF` is not sent
  - [x] Flag is re-sent on every subsequent command (not just the first)
  - [x] All 64 tests passing