### PR TITLE
ci: update Python workflow versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -48,11 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.15
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
-          python-version: 3.15
-          allow-prereleases: true
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- keep Python 3.8 and 3.9 in the test matrix for now
- run tests on Python 3.10 through 3.14
- use Python 3.14 for the publish job instead of the Python 3.15 prerelease
- remove `allow-prereleases` from `actions/setup-python`

## Validation
- `git diff --check -- .github/workflows/python-package.yml`
- YAML parse with Ruby `YAML.load_file`

## Notes
- The branch was created from the latest `origin/master` after the Dependabot workflow updates landed.
- The commit uses conventional commit format: `ci: update Python workflow versions`.