### PR TITLE
feat!: drop Python 3.8 and 3.9 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt") as f:
 
 setuptools.setup(
     name="greeclimate",
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     install_requires=requirements,
     author="Clifford Roche",
     author_email="",
@@ -19,6 +19,11 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["tests"]),
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py{310,311,312,313,314,315}
+skip_missing_interpreters = true
+
+[testenv]
+deps =
+    -rrequirements.txt
+    pytest
+    pytest-asyncio
+    pytest-cov
+commands =
+    pytest --cov-report=xml --cov=greeclimate tests/


### PR DESCRIPTION
## Summary

- Drop Python 3.8 and 3.9 from the GitHub Actions test matrix.
- Raise package metadata to `python_requires >=3.10`.
- Add Python 3.10-3.14 classifiers and commit the tox matrix starting at 3.10.

## Release impact

This PR uses a breaking conventional commit (`feat!`) with a `BREAKING CHANGE` footer so semantic-release should publish a new major package version after merge to `master`.

## Validation

- `.venv/bin/python -m pytest --cov-report=xml --cov=greeclimate tests/` passed with 105 tests on Python 3.14.5.