### PR TITLE
[codex] update CI runtime versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,11 +20,13 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements.txt
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -36,19 +41,24 @@ jobs:
       - name: Test with unittest
         run: |
           pytest --cov-report=xml --cov=greeclimate tests/
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v7
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   publish:
+    if: github.event_name == 'push'
     needs: build
     name: Publish to Github & NPM or Github Package Registry
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install dependencies
@@ -57,9 +67,11 @@ jobs:
           pip install setuptools wheel twine
           pip install importlib_metadata==7.2.1
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: "24.x"
+          check-latest: true
+          cache: npm
       - env:
           CI: true
         run: npm ci


### PR DESCRIPTION
## Summary
- Drop stale Python 3.8/3.9 CI support and align package metadata with Python 3.10+
- Update GitHub Actions workflow actions to current majors
- Keep release jobs on the Node 24 line with latest patch resolution for semantic-release 25
- Gate publishing to push events and define explicit workflow permissions

## Validation
- Parsed `.github/workflows/python-package.yml` with Ruby YAML parser
- Ran `git diff --check -- .github/workflows/python-package.yml`

Note: local `npm ci` could not be run because `npm` is not installed in this shell.