### PR TITLE
Revert PR #119 beep support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,25 +86,6 @@ device.target_humidity = 45
 await device.push_state_update()
 ```
 
-#### Disable beep
-
-In-door units have a very annoying beep on each status push.
-Hopefully, there is a parameter that can help to avoid it.
-
-Unfortunately, it doesn't work on some firmware versions.
-
-```python
-device = Device(...)
-device.beep = False
-await device.push_state_update()
-```
-
-This setting is not stored on the device and must be set in python each time you want to use it.
-
-**Based on the following discussion**
-
-- [Command to disable beeping](https://github.com/tomikaa87/gree-remote/issues/44)
-
 ## Debugging
 
 Maybe the reason you're here is that you're working with Home Assistant and your device isn't being detected.

--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -179,8 +179,6 @@ class Device(DeviceProtocol2, Taskable):
         self.check_version = True
         self._properties = {}
         self._dirty = []
-        self._beep = False
-        self._beep_dirty = False
 
         self._valid_state: asyncio.Event = asyncio.Event()
         self._valid_state.clear()
@@ -314,7 +312,7 @@ class Device(DeviceProtocol2, Taskable):
     async def push_state_update(self):
         """Push any pending state updates to the unit
         """
-        if not self._dirty and not self._beep_dirty:
+        if not self._dirty:
             return
 
         if not self.device_cipher:
@@ -333,10 +331,6 @@ class Device(DeviceProtocol2, Taskable):
                     Props.TEMP_UNIT.value
                 )
 
-        if not self._beep:
-            self._logger.debug("Disable buzzer")
-            props["Buzzer_ON_OFF"] = 1
-
         try:
             await self.send(self.create_command_message(self.device_info, **props))
 
@@ -344,7 +338,6 @@ class Device(DeviceProtocol2, Taskable):
             raise DeviceTimeoutError
         else:
             self._dirty.clear()
-            self._beep_dirty = False
 
 
     def __eq__(self, other):
@@ -598,15 +591,3 @@ class Device(DeviceProtocol2, Taskable):
     def water_full(self) -> Optional[bool]:
         prop = self.get_property(Props.WATER_FULL)
         return bool(prop) if prop is not None else None
-
-    @property
-    def beep(self) -> bool:
-        return self._beep
-
-    @beep.setter
-    def beep(self, value: bool):
-        self._beep = bool(value)
-        if not self._beep:
-            self._beep_dirty = True
-        else:
-            self._beep_dirty = False

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -388,7 +388,6 @@ async def test_set_properties(cipher, send):
     device.steady_heat = True
     device.power_save = True
     device.target_humidity = 30
-    device.beep = True
 
     await device.push_state_update()
     send.assert_called_once()
@@ -744,7 +743,7 @@ def test_device_key_set_get():
     device.device_key = "fake_key"
     assert device.device_key == "fake_key"
 
-
+    
 @pytest.mark.asyncio
 async def has_valid_state_with_valid_properties(cipher, send):
     """Check that the device has a valid state with valid properties."""
@@ -767,57 +766,4 @@ async def request_version_timeout_error(cipher, send):
     send.side_effect = asyncio.TimeoutError
 
     with pytest.raises(DeviceTimeoutError):
-        await device.request_version()
-
-
-@pytest.mark.asyncio
-async def test_disable_beep(cipher, send):
-    """Check that disabled beep add Buzzer_ON_OFF."""
-    device = await generate_device_mock_async()
-
-    device.beep = False
-    await device.push_state_update()
-    assert send.call_count == 1
-    assert set(send.call_args_list[0].args[0]["pack"]["opt"]) == {"Buzzer_ON_OFF"}
-
-    assert not device.beep
-
-    send.reset_mock()
-
-    device.power = False
-    device.beep = True
-    await device.push_state_update()
-    assert send.call_count == 1
-    assert set(send.call_args_list[0].args[0]["pack"]["opt"]) == {"Pow"}
-
-    assert device.beep
-
-
-@pytest.mark.asyncio
-async def test_disable_beep_timeout_stays_dirty(cipher, send):
-    """Check that disabled beep is retained after push timeout."""
-    device = await generate_device_mock_async()
-
-    device.beep = False
-    send.reset_mock()
-    send.side_effect = asyncio.TimeoutError
-
-    with pytest.raises(DeviceTimeoutError):
-        await device.push_state_update()
-
-    send.side_effect = None
-    await device.push_state_update()
-    assert send.call_count == 2
-    assert set(send.call_args_list[1].args[0]["pack"]["opt"]) == {"Buzzer_ON_OFF"}
-
-
-@pytest.mark.asyncio
-async def test_enable_beep_clears_dirty_without_update(cipher, send):
-    """Check that enabling beep cancels a pending beep-only update."""
-    device = await generate_device_mock_async()
-
-    device.beep = False
-    device.beep = True
-    await device.push_state_update()
-
-    assert send.call_count == 0
+        await device.request_version() 


### PR DESCRIPTION
Reverts PR #119 / merge commit eb9f6a076c4b9a11868e13284359bfa927ad0201.

This removes the beep on/off property, README section, and associated tests.

Verification:
- `./.venv/bin/python -m pytest` passed: 105 passed