### PR TITLE
Fix buzzer control on newer Gree firmwares

### DIFF
--- a/greeclimate/device.py
+++ b/greeclimate/device.py
@@ -336,6 +336,9 @@ class Device(DeviceProtocol2, Taskable):
             self._logger.debug("Disabling buzzer for command")
             props["Buzzer_ON_OFF"] = 1
 
+        # Newer firmwares are using this property to control the buzzer
+        props["BuzzerCtrl"] = 1 if self._buzzer else 0
+
         try:
             await self.send(self.create_command_message(self.device_info, **props))
 


### PR DESCRIPTION
Newer firmware versions utilize BuzzerCtrl instead of Buzzer_ON_OFF to manage buzzer behavior. Note that the control logic between the two parameters is inverted:

- Buzzer Active: Buzzer_ON_OFF = 0 | BuzzerCtrl = 1
- Buzzer Inactive: Buzzer_ON_OFF = 1 | BuzzerCtrl = 0
 