### PR TITLE
Fix handling of mixed-case bindOk responses

### DIFF
--- a/greeclimate/network.py
+++ b/greeclimate/network.py
@@ -231,6 +231,8 @@ class DeviceProtocol2(DeviceProtocolBase2):
         }
         try:
             resp = obj.get("pack", {}).get("t")
+            if isinstance(resp, str):
+                resp = resp.casefold()
             handler = handlers.get(resp, self.handle_unknown_packet)
             param = params.get(resp, lambda o, a: (o, a))(obj, addr)
             handler(*param)


### PR DESCRIPTION
## Summary

Some Gree devices return the bind response type as `bindOk` instead of the expected lowercase `bindok`.

The response is otherwise valid and includes `r: 200` and the encryption key, but the case-sensitive packet-type lookup treats it as an unknown packet. This causes binding to time out even though the device replied successfully.

This change normalizes the `bindOk` response to the existing `bindok` value before dispatching it.

## Example response

```json
{
  "t": "pack",
  "i": 1,
  "uid": 0,
  "cid": "REDACTED",
  "tcid": "",
  "pack": {
    "t": "bindOk",
    "mac": "REDACTED",
    "r": 200,
    "key": "REDACTED"
  }
}