### PR TITLE
fix: fall back to CipherV2 when Discovery can't decrypt a scan reply with CipherV1

### DIFF
--- a/greeclimate/discovery.py
+++ b/greeclimate/discovery.py
@@ -6,7 +6,7 @@ from asyncio import Task
 from asyncio.events import AbstractEventLoop
 from ipaddress import IPv4Address
 
-from greeclimate.cipher import CipherV1
+from greeclimate.cipher import CipherV1, CipherV2
 from greeclimate.device import DeviceInfo
 from greeclimate.network import BroadcastListenerProtocol, IPAddr
 from greeclimate.taskable import Taskable
@@ -116,6 +116,25 @@ class Discovery(BroadcastListenerProtocol, Listener, Taskable):
 
         tasks = [l.device_found(device_info) for l in self._listeners]
         await asyncio.gather(*tasks, return_exceptions=True)
+
+    def _decrypt_pack(self, pack):
+        """Decrypt a scan reply, falling back to CipherV2 if CipherV1 fails.
+
+        Some Gree Wi-Fi modules only speak the GCM-based protocol, even
+        for the initial scan reply, so the generic CipherV1 fails to
+        decrypt them. Device.bind() already has this same CipherV1 ->
+        CipherV2 fallback; this brings Discovery in line with it. Returns
+        None if the reply is undecryptable under either cipher, so
+        packet_received's existing "unexpected response" handling takes
+        care of it.
+        """
+        try:
+            return self._cipher.decrypt(pack)
+        except Exception:
+            try:
+                return CipherV2().decrypt(pack)
+            except Exception:
+                return None
 
     def packet_received(self, obj, addr: IPAddr) -> None:
         """Event called when a packet is received and decoded."""

--- a/greeclimate/network.py
+++ b/greeclimate/network.py
@@ -125,6 +125,14 @@ class DeviceProtocolBase2(asyncio.DatagramProtocol):
         self._drained.set()
         super().resume_writing()
 
+    def _decrypt_pack(self, pack):
+        """Decrypt the pack field of a received packet.
+
+        Override to customize cipher selection (e.g. trying more than one
+        cipher for replies from not-yet-identified devices).
+        """
+        return self._cipher.decrypt(pack)
+
     def datagram_received(self, data: bytes, addr: IPAddr) -> None:
         """Handle an incoming datagram."""
         if len(data) == 0:
@@ -133,7 +141,7 @@ class DeviceProtocolBase2(asyncio.DatagramProtocol):
         obj = json.loads(data)
 
         if obj.get("pack"):
-            obj["pack"] = self._cipher.decrypt(obj["pack"])
+            obj["pack"] = self._decrypt_pack(obj["pack"])
 
         _LOGGER.debug("Received packet from %s:\n<- %s", addr[0], json.dumps(obj))
         self.packet_received(obj, addr)

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,7 +3,7 @@ from socket import SOCK_DGRAM
 from typing import Tuple, Union
 from unittest.mock import Mock
 
-from greeclimate.cipher import CipherV1, CipherBase
+from greeclimate.cipher import CipherV1, CipherV2, CipherBase
 
 DEFAULT_TIMEOUT = 1
 DISCOVERY_REQUEST = {"t": "scan"}
@@ -96,6 +96,14 @@ def encrypt_payload(data):
     """Encrypt the payload of responses quickly."""
     d = data.copy()
     cipher = CipherV1()
+    d["pack"], _ = cipher.encrypt(d["pack"])
+    return d
+
+
+def encrypt_payload_v2(data):
+    """Encrypt the payload of responses using CipherV2 (AES-GCM)."""
+    d = data.copy()
+    cipher = CipherV2()
     d["pack"], _ = cipher.encrypt(d["pack"])
     return d
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -12,7 +12,7 @@ from .common import (
     DISCOVERY_REQUEST,
     DISCOVERY_RESPONSE,
     Responder,
-    get_mock_device_info, encrypt_payload,
+    get_mock_device_info, encrypt_payload, encrypt_payload_v2,
 )
 
 
@@ -218,6 +218,87 @@ async def test_discover_devices_bad_data(netifaces, addr, family):
 
         assert response is not None
         assert len(response) == 0
+
+        sock.close()
+        serv.join(timeout=DEFAULT_TIMEOUT)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "addr,family", [(("127.0.0.1", 7000), socket.AF_INET)]
+)
+async def test_discover_devices_cipherv2_fallback(netifaces, addr, family):
+    """Devices that only encrypt their scan reply with CipherV2 (AES-GCM)
+    must still be discovered: Discovery should fall back to CipherV2 when
+    CipherV1 fails to decrypt the reply, same as Device.bind() already
+    does.
+    """
+    netifaces.return_value = {
+        2: [{"addr": addr[0], "netmask": "255.0.0.0", "peer": addr[0]}]
+    }
+
+    with Responder(family, addr[1]) as sock:
+
+        def responder(s):
+            (d, addr) = s.recvfrom(2048)
+            p = json.loads(d)
+            assert p == DISCOVERY_REQUEST
+
+            p = json.dumps(encrypt_payload_v2(DISCOVERY_RESPONSE))
+            s.sendto(p.encode(), addr)
+
+        serv = Thread(target=responder, args=(sock,))
+        serv.start()
+
+        discovery = Discovery(allow_loopback=True)
+        devices = await discovery.scan(wait_for=DEFAULT_TIMEOUT)
+
+        assert devices is not None
+        assert len(devices) == 1
+        assert devices[0].mac == DISCOVERY_RESPONSE["pack"]["mac"]
+
+        sock.close()
+        serv.join(timeout=DEFAULT_TIMEOUT)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "addr,family", [(("127.0.0.1", 7000), socket.AF_INET)]
+)
+async def test_discover_devices_undecryptable_reply_ignored(
+    netifaces, addr, family
+):
+    """A reply that fails to decrypt under both CipherV1 and CipherV2
+    should be discarded without raising, and should not prevent other
+    devices from being discovered.
+    """
+    netifaces.return_value = {
+        2: [{"addr": addr[0], "netmask": "255.0.0.0", "peer": addr[0]}]
+    }
+
+    with Responder(family, addr[1]) as sock:
+
+        def responder(s):
+            (d, addr) = s.recvfrom(2048)
+            p = json.loads(d)
+            assert p == DISCOVERY_REQUEST
+
+            bad = DISCOVERY_RESPONSE.copy()
+            bad["pack"] = "not-valid-base64-ciphertext"
+            s.sendto(json.dumps(bad).encode(), addr)
+
+            good = encrypt_payload(DISCOVERY_RESPONSE)
+            s.sendto(json.dumps(good).encode(), addr)
+
+        serv = Thread(target=responder, args=(sock,))
+        serv.start()
+
+        discovery = Discovery(allow_loopback=True)
+        devices = await discovery.scan(wait_for=DEFAULT_TIMEOUT)
+
+        assert devices is not None
+        assert len(devices) == 1
+        assert devices[0].mac == DISCOVERY_RESPONSE["pack"]["mac"]
 
         sock.close()
         serv.join(timeout=DEFAULT_TIMEOUT)


### PR DESCRIPTION
## Behavior change

`Discovery.datagram_received` only ever decrypts scan replies with the
generic `CipherV1` (AES-ECB) cipher, unlike `Device.bind()` which already
tries `CipherV1` then falls back to `CipherV2` (AES-GCM). Devices whose
firmware uses the newer GCM-only protocol for their scan reply (observed
on retrofitted and newer Gree Wi-Fi modules) fail to decrypt with
`CipherV1`, raising an unhandled `ValueError` inside the asyncio UDP
callback (`Data must be aligned to block boundary in ECB mode`), and are
silently dropped from discovery — they never appear in `discovery.devices`
even though they're on the network and respond to the scan.

This PR extracts the one-line decrypt call in
`DeviceProtocolBase2.datagram_received` (`network.py`) into a small
`_decrypt_pack()` hook, then has `Discovery` override just that hook to
try `CipherV1` then `CipherV2`, mirroring the existing fallback already in
`Device.bind()`. `Discovery._decrypt_pack` returns `None` when a reply is
undecryptable under both ciphers, which `packet_received`'s existing
"unexpected response" handling already covers — no new error-handling
code needed, and it's strictly better than today's behavior (a quiet,
already-existing log line instead of an unhandled exception).

## Why scope the fix this way

Two narrower/differently-shaped fixes were considered and rejected:

- **Patching `CipherV1.decrypt()`** to silently retry as `CipherV2` on
  failure. Rejected: it would change what "CipherV1" means for every
  caller in the codebase, not just discovery.
- **Adding the two-cipher retry logic directly inside the shared
  `DeviceProtocolBase2.datagram_received`**, rather than via an
  overridable `_decrypt_pack()` hook. Rejected: that method is used by
  both `Discovery` (scanning for *unknown* devices, where the correct
  cipher genuinely isn't known yet) and `Device` (an already-bound device
  with an established, known-correct cipher). A bound `Device` shouldn't
  silently retry with a different cipher on every decrypt failure on an
  established connection — that risks masking real transmission errors
  and adds an extra decrypt attempt to the hot path of every status poll,
  for a case that should never legitimately happen post-bind.

`_decrypt_pack()` keeps `Device`'s code path provably unaffected (it
doesn't override the hook, so it still calls `self._cipher.decrypt()`
directly, identical to before) while letting `Discovery` override just the
part that varies. It also avoids duplicating `datagram_received`'s
surrounding logic, so any future change to that shared logic (parsing,
logging, dispatch) automatically applies to `Discovery` too instead of
needing to be kept in sync by hand across two copies.

## Context / device info

Verified against 5 real Gree/Saunier Duval AC units on a live home
network (1 built-in Wi-Fi unit, 4 retrofitted Wi-Fi modules). Before this
fix, only the 1 built-in-Wi-Fi unit was discoverable; the other 4 sent
valid scan replies but were never found. After the fix, all 5 are
discovered and bind successfully. This appears to be the same root cause
reported (without a fix) in:
- home-assistant/core#82452 "Newer GREE unit not discoverable"
- home-assistant/core#148458 "Gree not discovered by home assistant"

Also deployed and verified end-to-end inside an actual Home Assistant
instance (as a drop-in-replacement custom_component built from this exact
patch): all 5 units discovered and controllable after the fix, confirmed
stable across a restart.

## Test plan

```
python -m venv .venv && source .venv/bin/activate
pip install -r requirements.txt pytest pytest-asyncio pytest-cov
pytest --cov-report=xml --cov=greeclimate tests/
flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
```

- Full suite: 110 passed (108 existing + 2 new), no regressions.
- Added `test_discover_devices_cipherv2_fallback` (reproduces the bug:
  fails with the exact `ValueError` above when the fix is reverted, passes
  with it) and `test_discover_devices_undecryptable_reply_ignored`
  (confirms a reply undecryptable under both ciphers is discarded
  gracefully and doesn't block discovery of other devices).
- `flake8 --select=E9,F63,F7,F82`: 0 errors on changed files. The
  `--max-complexity=10 --max-line-length=127` informational check reports
  the same pre-existing findings (same issue types, shifted line numbers)
  as unpatched `master` — nothing new introduced.
- Also manually re-verified end-to-end against the real hardware described
  above (discovery + bind + state read) with this exact patch, and inside
  an actual Home Assistant instance.
